### PR TITLE
fix: シール削除時にボード上の配置も連動して削除する

### DIFF
--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -5,7 +5,7 @@ struct StickerLibraryView: View {
     @Environment(\.modelContext) private var modelContext
     @Query(sort: \Sticker.createdAt, order: .reverse) private var stickers: [Sticker]
     @Query private var boards: [Board]
-    @State private var stickerToDelete: Sticker?
+    @State private var deleteInfo: (sticker: Sticker, boards: [Board])?
     @State private var previewSticker: Sticker?
     @Namespace private var previewNamespace
     var onAddSticker: () -> Void = {}
@@ -43,23 +43,18 @@ struct StickerLibraryView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbarBackground(AppTheme.backgroundPrimary, for: .navigationBar)
         .alert("シールを削除", isPresented: Binding(
-            get: { stickerToDelete != nil },
-            set: { if !$0 { stickerToDelete = nil } }
-        )) {
+            get: { deleteInfo != nil },
+            set: { if !$0 { deleteInfo = nil } }
+        ), presenting: deleteInfo) { info in
             Button("削除", role: .destructive) {
-                if let sticker = stickerToDelete {
-                    deleteSticker(sticker)
-                }
+                deleteSticker(info.sticker, from: info.boards)
             }
             Button("キャンセル", role: .cancel) {}
-        } message: {
-            if let sticker = stickerToDelete {
-                let usedBoardCount = boardsUsing(sticker).count
-                if usedBoardCount > 0 {
-                    Text("このシールは\(usedBoardCount)個のボードで使用されています。削除するとボードからも取り除かれます。")
-                } else {
-                    Text("このシールをコレクションから削除しますか？")
-                }
+        } message: { info in
+            if info.boards.isEmpty {
+                Text("このシールをコレクションから削除しますか？")
+            } else {
+                Text("このシールは\(info.boards.count)個のボードで使用されています。削除するとボードからも取り除かれます。")
             }
         }
     }
@@ -123,7 +118,7 @@ struct StickerLibraryView: View {
                             .accessibilityHint("タップしてプレビューを表示")
                             .contextMenu {
                                 Button(role: .destructive) {
-                                    stickerToDelete = sticker
+                                    deleteInfo = (sticker, boardsUsing(sticker))
                                 } label: {
                                     Label("削除", systemImage: "trash")
                                 }
@@ -141,14 +136,14 @@ struct StickerLibraryView: View {
         }
     }
 
-    private func deleteSticker(_ sticker: Sticker) {
-        for board in boardsUsing(sticker) {
+    private func deleteSticker(_ sticker: Sticker, from usedBoards: [Board]) {
+        for board in usedBoards {
             board.placements = board.placements.filter { $0.stickerId != sticker.id }
             board.updatedAt = Date()
         }
         ImageStorage.delete(fileName: sticker.imageFileName)
         modelContext.delete(sticker)
-        stickerToDelete = nil
+        deleteInfo = nil
     }
 
     // MARK: - さらに追加カード


### PR DESCRIPTION
## Summary
- シールライブラリからシールを削除する際、ボード上で使用されている場合に警告アラートを表示するよう追加
- 削除確定時に、全ボードから該当シールの `StickerPlacement` を連動して除去するよう修正
- 使用されていないシールは従来通りの削除確認のみ表示

## 変更内容
- `StickerLibraryView` に `@Query private var boards: [Board]` を追加
- `boardsUsing(_:)` メソッドでボード使用状況をチェック
- アラートメッセージを使用状況に応じて動的に切り替え
- `deleteSticker()` でボードの `placements` からも該当シールを除去

## Test plan
- [ ] ボード未使用のシールを削除 → 通常の確認メッセージが表示されること
- [ ] ボードで使用中のシールを削除 → 使用ボード数を含む警告メッセージが表示されること
- [ ] 警告後に削除を実行 → シールとボード上の配置が両方とも削除されること
- [ ] キャンセルを選択 → シールもボード配置も変更なしであること
- [ ] 複数ボードで使用中のシール → 全ボードから配置が除去されること

Close #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)