### PR TITLE
fix: 「背面」操作でシールが消える問題を修正

### DIFF
--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -560,32 +560,32 @@ struct BoardEditorView: View {
 
     // MARK: - Z軸操作
 
-    private func bringToFront(_ placement: StickerPlacement) {
-        // 対象を最前面にして全体を正規化（zIndex を 0 始まりに再割り振り）
-        var sorted = placements.enumerated().sorted { $0.element.zIndex < $1.element.zIndex }
-        // 対象を末尾（最前面）に移動
-        if let sortedIdx = sorted.firstIndex(where: { $0.element.id == placement.id }) {
-            let item = sorted.remove(at: sortedIdx)
-            sorted.append(item)
+    private func reorderAndNormalizeZIndex(for placement: StickerPlacement, moveToFront: Bool) {
+        guard let targetIndex = placements.firstIndex(where: { $0.id == placement.id }) else { return }
+
+        var sortedIndices = placements.indices.sorted { placements[$0].zIndex < placements[$1].zIndex }
+
+        if let position = sortedIndices.firstIndex(of: targetIndex) {
+            let index = sortedIndices.remove(at: position)
+            if moveToFront {
+                sortedIndices.append(index)
+            } else {
+                sortedIndices.insert(index, at: 0)
+            }
         }
-        for (newZ, entry) in sorted.enumerated() {
-            placements[entry.offset].zIndex = newZ
+
+        for (newZ, originalIndex) in sortedIndices.enumerated() {
+            placements[originalIndex].zIndex = newZ
         }
         saveBoard()
     }
 
+    private func bringToFront(_ placement: StickerPlacement) {
+        reorderAndNormalizeZIndex(for: placement, moveToFront: true)
+    }
+
     private func sendToBack(_ placement: StickerPlacement) {
-        // 対象を最背面にして全体を正規化（zIndex を 0 始まりに再割り振り）
-        var sorted = placements.enumerated().sorted { $0.element.zIndex < $1.element.zIndex }
-        // 対象を先頭（最背面）に移動
-        if let sortedIdx = sorted.firstIndex(where: { $0.element.id == placement.id }) {
-            let item = sorted.remove(at: sortedIdx)
-            sorted.insert(item, at: 0)
-        }
-        for (newZ, entry) in sorted.enumerated() {
-            placements[entry.offset].zIndex = newZ
-        }
-        saveBoard()
+        reorderAndNormalizeZIndex(for: placement, moveToFront: false)
     }
 
     private func removeFromBoard(_ placement: StickerPlacement) {


### PR DESCRIPTION
## Summary
- ボード編集画面でシールを選択して「背面」を押すと、zIndex が負の値になり背景より後ろに描画されてシールが消えて見える問題を修正
- `bringToFront` / `sendToBack` の両方で zIndex を 0 始まりの連番に正規化する方式に変更し、シールが常に背景より前面に表示されるようにした
- zIndex の無限増加・無限減少も防止

## Test plan
- [ ] ボード上にシールを複数配置する
- [ ] シールを選択して「背面」を押し、シールが消えずに最背面に移動することを確認
- [ ] 「前面」を押し、シールが最前面に移動することを確認
- [ ] 複数回「背面」「前面」を繰り返しても正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)