### PR TITLE
feat: Xcode MCPサーバーの設定を追加

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "xcode": {
+      "command": "xcrun",
+      "args": ["mcpbridge"]
+    }
+  }
+}


### PR DESCRIPTION
## Summary\n\n- プロジェクトルートに `.mcp.json` を追加し、Xcode 26.3 内蔵の MCP サーバーに接続できるようにした\n- Claude Code などの AI エージェントから Xcode のビルド・テスト・プレビュー・ドキュメント検索（全20ツール）に直接アクセス可能になる\n\n## 動作確認済み\n\n- [x] `claude mcp list` で `xcode: ✓ Connected` を確認\n- [x] `XcodeListWindows` でワークスペース情報を取得できることを確認\n- [x] `BuildProject` でビルド成功を確認（エラーなし、3.9秒）\n\n## 前提条件\n\n- Xcode 26.3 以降\n- Xcode → Settings → Intelligence → 「Xcode Tools」が ON\n- Xcode が起動中であること\n\nClose #41\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)