### PR TITLE
feat: ボード編集画面の写真保存時に確認モーダルを追加

### DIFF
--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -12,6 +12,7 @@ struct BoardEditorView: View {
     @State private var placements: [StickerPlacement] = []
     @State private var selectedPlacementId: UUID?
     @State private var showingStickerPicker = false
+    @State private var showingSaveConfirmation = false
     @State private var showingSaveResult = false
     @State private var saveResultSuccess = false
     @State private var canvasSize: CGSize = .zero
@@ -120,7 +121,7 @@ struct BoardEditorView: View {
             }
             ToolbarItem(placement: .primaryAction) {
                 Button {
-                    saveBoardAsImage()
+                    showingSaveConfirmation = true
                 } label: {
                     Image(systemName: "arrow.down.to.line")
                         .font(.system(size: 15, weight: .medium))
@@ -166,6 +167,14 @@ struct BoardEditorView: View {
                 }
                 .presentationDetents([.medium, .large])
             }
+        }
+        .alert("写真を保存", isPresented: $showingSaveConfirmation) {
+            Button("保存") {
+                saveBoardAsImage()
+            }
+            Button("キャンセル", role: .cancel) {}
+        } message: {
+            Text("ボードを写真に保存しますか？")
         }
         .alert(
             saveResultSuccess ? "保存完了" : "エラー",


### PR DESCRIPTION
## Summary
- ボード編集画面（BoardEditorView）の写真保存ボタンタップ時に、確認アラートを表示するように変更
- 「保存」選択で写真保存、「キャンセル」選択でモーダルを閉じる
- 誤タップによる意図しない保存を防止

## Changes
- `BoardEditorView.swift`: `showingSaveConfirmation` state追加、ツールバーボタンのアクションを確認モーダル表示に変更、`.alert` で確認ダイアログを実装

## Test plan
- [x] ビルド成功を確認
- [x] 既存テスト66件すべてパス
- [ ] 保存ボタンタップ → 確認アラートが表示される
- [ ] 「保存」タップ → カメラロールに保存される
- [ ] 「キャンセル」タップ → 何もせずアラートが閉じる

Close #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)