### PR TITLE
fix: アプリ起動時にボードカードの幅が異常に狭くなる問題を修正

### DIFF
--- a/StickerBoard/App/AppTheme.swift
+++ b/StickerBoard/App/AppTheme.swift
@@ -83,12 +83,16 @@ extension AppTheme {
     /// 現在のウィンドウシーンから画面サイズを取得する
     @MainActor
     static var screenBounds: CGRect {
-        guard let scene = UIApplication.shared.connectedScenes
-            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        else {
-            return .zero
+        let scenes = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+        // foregroundActive を優先し、なければ任意の接続済みシーンにフォールバック
+        if let active = scenes.first(where: { $0.activationState == .foregroundActive }) {
+            return active.screen.bounds
         }
-        return scene.screen.bounds
+        if let scene = scenes.first {
+            return scene.screen.bounds
+        }
+        return .zero
     }
 }
 

--- a/StickerBoard/Views/Home/HomeView.swift
+++ b/StickerBoard/Views/Home/HomeView.swift
@@ -144,6 +144,8 @@ struct HomeView: View {
         let screen = AppTheme.screenBounds
         let canvasWidth = screen.width - (AppTheme.EditorLayout.horizontalPadding * 2)
         let canvasHeight = screen.height - AppTheme.EditorLayout.verticalChromeHeight
+        // 起動直後に screenBounds が未確定の場合は妥当なデフォルト比率を返す
+        guard canvasWidth > 0, canvasHeight > 0 else { return 0.75 }
         return canvasWidth / canvasHeight
     }
 


### PR DESCRIPTION
## Summary
- `AppTheme.screenBounds` が `foregroundActive` なシーンのみを検索していたため、起動直後にシーンが未アクティブ状態で `CGRect.zero` を返し、ボードカードのアスペクト比が極端に縦長（≈0.197）になっていた
- 任意の接続済み `UIWindowScene` へのフォールバックを追加し、起動直後でも正しい画面サイズを取得できるように修正
- `boardCardAspectRatio` に安全ガードを追加し、万が一 `screenBounds` が `.zero` でも妥当なデフォルト比率（0.75）を返すように対応

Close #61

## Test plan
- [x] ビルド成功を確認
- [x] 全71テスト合格を確認
- [ ] 実機でアプリを起動し、ホーム画面のボードカードが正常な幅で表示されることを確認
- [ ] タブ切り替え後もレイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)