### PR TITLE
feat: シールプレビューにアクションボタンを追加

### DIFF
--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -44,9 +44,15 @@ struct StickerLibraryView: View {
                         }
                     },
                     onDelete: {
+                        withAnimation(.spring(duration: 0.35, bounce: 0.2)) {
+                            previewSticker = nil
+                        }
                         deleteInfo = (sticker, boardsUsing(sticker))
                     },
                     onMaskEdit: {
+                        withAnimation(.spring(duration: 0.35, bounce: 0.2)) {
+                            previewSticker = nil
+                        }
                         startMaskEdit(sticker)
                     }
                 )
@@ -277,7 +283,6 @@ struct StickerPreviewOverlay: View {
                 // アクションボタン
                 HStack(spacing: 16) {
                     Button {
-                        onDismiss()
                         onDelete()
                     } label: {
                         Label("削除", systemImage: "trash")
@@ -291,7 +296,6 @@ struct StickerPreviewOverlay: View {
                     .accessibilityLabel("シールを削除")
 
                     Button {
-                        onDismiss()
                         onMaskEdit()
                     } label: {
                         Label("再編集", systemImage: "eraser.line.dashed")


### PR DESCRIPTION
## Summary\n- シールプレビューオーバーレイに「削除」「再編集」アクションボタンを追加し、長押しに依存しない操作導線を確保\n- 縦長画像でもボタンがタブバーと重ならないようレイアウトを調整\n- 長押しcontextMenuは既存ユーザー向けショートカットとして併存\n\nclose #63\n\n## Test plan\n- [x] ビルド成功を確認\n- [x] 全71テストがパス\n- [ ] シールプレビューで「削除」ボタンをタップ → 削除確認ダイアログが表示される\n- [ ] シールプレビューで「再編集」ボタンをタップ → マスク編集画面が開く\n- [ ] 縦長・横長・正方形のシールでボタンがタブバーと重ならないことを確認\n- [ ] 長押しcontextMenuが引き続き動作する\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)