### PR TITLE
fix: StickerPreviewOverlayの永続スピナーをエラー表示に修正

### DIFF
--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -279,7 +279,15 @@ struct StickerPreviewOverlay: View {
                             .scaledToFit()
                             .accessibilityLabel("シールのプレビュー")
                     } else {
-                        ProgressView()
+                        VStack(spacing: 12) {
+                            Image(systemName: "exclamationmark.triangle")
+                                .font(.system(size: 40))
+                                .foregroundStyle(.white.opacity(0.6))
+                            Text("画像を読み込めませんでした")
+                                .font(.system(size: 14, design: .rounded))
+                                .foregroundStyle(.white.opacity(0.6))
+                        }
+                        .accessibilityLabel("画像の読み込みに失敗しました")
                     }
                 }
                 .matchedGeometryEffect(id: sticker.id, in: namespace)


### PR DESCRIPTION
## Summary\n- `StickerPreviewOverlay` で `ImageStorage.load()` が `nil` を返した際に `ProgressView()` が永久に回り続ける問題を修正\n- `ProgressView` の代わりに `exclamationmark.triangle` アイコン + 「画像を読み込めませんでした」テキストのエラー状態UIを表示\n- アクセシビリティラベルも適切に設定\n\nClose #67\n\n## Test plan\n- [ ] 全71テスト通過済み（`xcodebuild test`）\n- [ ] 画像ファイルが正常な場合、プレビューが従来通り表示されることを確認\n- [ ] 画像ファイルが存在しない/破損している場合、警告アイコンとエラーメッセージが表示されることを確認\n- [ ] VoiceOverで「画像の読み込みに失敗しました」と読み上げられることを確認\n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)