### PR TITLE
feat: シールライブラリにページネーション（無限スクロール）を導入

### DIFF
--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -295,9 +295,14 @@ struct StickerLibraryView: View {
         )
         descriptor.fetchOffset = displayedStickers.count
         descriptor.fetchLimit = pageSize
-        guard let page = try? modelContext.fetch(descriptor) else { return }
-        displayedStickers.append(contentsOf: page)
-        hasMorePages = page.count == pageSize
+        do {
+            let page = try modelContext.fetch(descriptor)
+            displayedStickers.append(contentsOf: page)
+            hasMorePages = page.count == pageSize
+        } catch {
+            print("Error fetching next page of stickers: \(error)")
+            hasMorePages = false
+        }
     }
 
     // MARK: - さらに追加カード


### PR DESCRIPTION
## Summary
- `@Query` の全件ロードを `FetchDescriptor` + `fetchLimit`/`fetchOffset` による段階的読み込みに変更
- 30枚ずつロードし、スクロール末尾で自動的に次ページを取得（無限スクロール）
- `fetchCount` で総数を軽量に取得し、全シールをメモリに展開しない設計に改善

## Test plan
- [ ] シールが0枚の状態で空の状態表示が正常に表示される
- [ ] シールが30枚以下の場合、全件が表示されローディングインジケーターが出ない
- [ ] シールが31枚以上の場合、スクロール末尾で自動的に次ページがロードされる
- [ ] シールを削除した際、リストとカウンターが正しく更新される
- [ ] タブ切り替え後に戻った際、新規追加されたシールが反映される

🤖 Generated with [Claude Code](https://claude.com/claude-code)