### PR TITLE
fix: Vision未検出時に元画像をフォールバックで返すように修正

### DIFF
--- a/StickerBoard/Services/BackgroundRemover.swift
+++ b/StickerBoard/Services/BackgroundRemover.swift
@@ -54,11 +54,7 @@ struct BackgroundRemover {
     static func removeBackgroundWithMask(from image: UIImage) async throws -> BackgroundRemovalResult {
         let normalized = normalizeOrientation(image)
         #if targetEnvironment(simulator)
-        let renderer = UIGraphicsImageRenderer(size: normalized.size)
-        let whiteMask = renderer.image { ctx in
-            UIColor.white.setFill()
-            ctx.fill(CGRect(origin: .zero, size: normalized.size))
-        }
+        let whiteMask = createWhiteMask(size: normalized.size)
         return BackgroundRemovalResult(processedImage: normalized, maskImage: whiteMask, originalImage: normalized)
         #else
         return try removeBackgroundWithMaskReal(from: normalized)
@@ -81,11 +77,7 @@ struct BackgroundRemover {
         }
 
         guard let (observation, handler) = try performInstanceMask(on: cgImage) else {
-            let renderer = UIGraphicsImageRenderer(size: image.size)
-            let whiteMask = renderer.image { ctx in
-                UIColor.white.setFill()
-                ctx.fill(CGRect(origin: .zero, size: image.size))
-            }
+            let whiteMask = createWhiteMask(size: image.size)
             return BackgroundRemovalResult(processedImage: image, maskImage: whiteMask, originalImage: image)
         }
 
@@ -151,6 +143,14 @@ struct BackgroundRemover {
             throw BackgroundRemoverError.noResult
         }
         return results
+    }
+
+    private static func createWhiteMask(size: CGSize) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: size)
+        return renderer.image { ctx in
+            UIColor.white.setFill()
+            ctx.fill(CGRect(origin: .zero, size: size))
+        }
     }
 
     private static func performInstanceMask(on cgImage: CGImage) throws -> (VNInstanceMaskObservation, VNImageRequestHandler)? {


### PR DESCRIPTION
## Summary
- `VNGenerateForegroundInstanceMaskRequest` が前景を検出できない画像（イラスト・ピクセルアートなど）でエラーになる問題を修正
- `performInstanceMask` の戻り値をOptionalに変更し、結果なし時は各メソッドで元画像をそのまま返すフォールバックを追加
- マスク編集フロー（`removeBackgroundWithMaskReal`）では白マスクを返し、手動でのマスク調整が可能

## Test plan
- [ ] 実機で写真ライブラリからイラスト/ピクセルアート画像を選択し、エラーにならず元画像がシールとして保存されることを確認
- [ ] 実機で通常の写真（実写）を選択し、従来通り背景除去が正常に動作することを確認
- [ ] マスク編集フローで前景未検出時に白マスクが表示され、手動編集できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)