### PR TITLE
a11y: MainTabView・HomeViewのVoiceOver対応

### DIFF
--- a/StickerBoard/Views/Home/HomeView.swift
+++ b/StickerBoard/Views/Home/HomeView.swift
@@ -53,6 +53,8 @@ struct HomeView: View {
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(AppTheme.textSecondary)
                 }
+                .accessibilityLabel("設定")
+                .accessibilityHint("設定画面を開きます")
             }
             ToolbarItem(placement: .principal) {
                 Text("シールボード")
@@ -67,6 +69,8 @@ struct HomeView: View {
                         .font(.system(size: 17, weight: .medium))
                         .foregroundStyle(AppTheme.textSecondary)
                 }
+                .accessibilityLabel("ヘルプ")
+                .accessibilityHint("使い方ガイドを表示します")
             }
         }
         .navigationDestination(isPresented: $showingSettings) {
@@ -120,6 +124,10 @@ struct HomeView: View {
                         .onTapGesture {
                             selectedBoard = board
                         }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(board.title)、シール\(board.placements.count)枚")
+                        .accessibilityHint("タップしてボードを編集します")
+                        .accessibilityAddTraits(.isButton)
                         .id(board.id.uuidString)
                 }
 
@@ -214,6 +222,8 @@ struct HomeView: View {
                                     .background(.ultraThinMaterial.opacity(0.6))
                                     .clipShape(Circle())
                             }
+                            .accessibilityLabel("メニュー")
+                            .accessibilityHint("ボードの名前変更や削除ができます")
                         }
                         .padding(.horizontal, 16)
                         .padding(.bottom, 14)
@@ -287,6 +297,8 @@ struct HomeView: View {
             .aspectRatio(boardCardAspectRatio, contentMode: .fit)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("新しいボードを作る")
+        .accessibilityHint("タップして新しいボードを作成します")
         .containerRelativeFrame(.horizontal)
     }
 
@@ -309,6 +321,9 @@ struct HomeView: View {
                     .animation(.spring(duration: 0.3), value: currentPageIndex)
             }
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("ページ \(currentPageIndex + 1) / \(boards.count + 1)")
+        .accessibilityValue(currentPageIndex < boards.count ? boards[currentPageIndex].title : "新しいボードを作る")
     }
 
     private var currentPageIndex: Int {
@@ -372,6 +387,8 @@ struct HomeView: View {
                         .foregroundStyle(.white)
                 }
             }
+            .accessibilityLabel("新しいボードを作る")
+            .accessibilityHint("タップして新しいボードを作成します")
         }
         .opacity(animateIn ? 1 : 0)
         .offset(y: animateIn ? 0 : 20)

--- a/StickerBoard/Views/Home/MainTabView.swift
+++ b/StickerBoard/Views/Home/MainTabView.swift
@@ -69,6 +69,9 @@ struct MainTabView: View {
                 )
                 .frame(maxWidth: .infinity)
             }
+            .accessibilityLabel("ホーム")
+            .accessibilityHint("ボード一覧を表示します")
+            .accessibilityAddTraits(selectedTab == .home ? .isSelected : [])
 
             // 撮影ボタン（中央・浮き上がり）
             Button {
@@ -94,6 +97,8 @@ struct MainTabView: View {
                 }
                 .frame(maxWidth: .infinity)
             }
+            .accessibilityLabel("シールを追加")
+            .accessibilityHint("カメラを開いてシールを撮影します")
 
             // ライブラリタブ
             Button {
@@ -107,6 +112,9 @@ struct MainTabView: View {
                 )
                 .frame(maxWidth: .infinity)
             }
+            .accessibilityLabel("ライブラリ")
+            .accessibilityHint("シール一覧を表示します")
+            .accessibilityAddTraits(selectedTab == .library ? .isSelected : [])
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 10)


### PR DESCRIPTION
## Summary
- MainTabView のタブボタン（ホーム・ライブラリ）と撮影ボタン（+）に `accessibilityLabel` / `accessibilityHint` / `accessibilityAddTraits` を追加
- HomeView の設定ボタン・ヘルプボタンに `accessibilityLabel` / `accessibilityHint` を追加
- ボードカードを `accessibilityElement(children: .combine)` でグループ化し、ボード名＋シール枚数のラベルとタップヒントを設定
- メニューボタン（...）に `accessibilityLabel("メニュー")` を追加
- ページインジケーターを `accessibilityElement(children: .ignore)` でグループ化し、現在のページ番号とボード名を通知
- 新規ボードカードと空状態のボタンにアクセシビリティラベル・ヒントを追加

## Test plan
- [x] 既存テスト全80件パス確認済み
- [ ] 実機でVoiceOverを有効にし、全タブボタンが正しく読み上げられること
- [ ] ボードカードのタップでボード名・シール枚数が読み上げられること
- [ ] ページインジケーターで現在ページが通知されること
- [ ] メニューボタン・設定・ヘルプボタンが正しくラベル付けされていること

Close #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)