### PR TITLE
fix: 新しいボードが右側（末尾）に追加されるようソート順を修正

### DIFF
--- a/StickerBoard/Views/Board/BoardListView.swift
+++ b/StickerBoard/Views/Board/BoardListView.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 struct BoardListView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \Board.updatedAt, order: .reverse) private var boards: [Board]
+    @Query(sort: \Board.createdAt, order: .forward) private var boards: [Board]
 
     @State private var showingNewBoard = false
     @State private var newBoardTitle = ""

--- a/StickerBoard/Views/Home/HomeView.swift
+++ b/StickerBoard/Views/Home/HomeView.swift
@@ -3,7 +3,7 @@ import SwiftData
 
 struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \Board.updatedAt, order: .reverse) private var boards: [Board]
+    @Query(sort: \Board.createdAt, order: .forward) private var boards: [Board]
 
     private let newBoardCardID = "new-board"
 

--- a/StickerBoardTests/BoardTests.swift
+++ b/StickerBoardTests/BoardTests.swift
@@ -170,6 +170,89 @@ struct BoardTests {
         #expect(board.backgroundPattern.secondaryColorHex == "F2A7B0")
     }
 
+    // MARK: - ソート順（作成日時の昇順）
+
+    @Test func ボードはcreatedAtの昇順でソートされる_新しいボードが末尾に来る() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        // 3つのボードを順番に作成（createdAt に差をつける）
+        let board1 = Board(title: "最初のボード")
+        context.insert(board1)
+
+        // createdAt をずらして明示的に順序を設定
+        let board2 = Board(title: "2番目のボード")
+        board2.createdAt = board1.createdAt.addingTimeInterval(1)
+        context.insert(board2)
+
+        let board3 = Board(title: "3番目のボード")
+        board3.createdAt = board1.createdAt.addingTimeInterval(2)
+        context.insert(board3)
+
+        try context.save()
+
+        // createdAt 昇順で取得（HomeView / BoardListView と同じソート）
+        var descriptor = FetchDescriptor<Board>(
+            sortBy: [SortDescriptor(\Board.createdAt, order: .forward)]
+        )
+        let boards = try context.fetch(descriptor)
+
+        #expect(boards.count == 3)
+        #expect(boards[0].title == "最初のボード")
+        #expect(boards[1].title == "2番目のボード")
+        #expect(boards[2].title == "3番目のボード")
+    }
+
+    @Test func 新しいボードを追加するとcreatedAt昇順で末尾に配置される() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let existingBoard = Board(title: "既存ボード")
+        context.insert(existingBoard)
+        try context.save()
+
+        // 少し後に新しいボードを作成
+        let newBoard = Board(title: "新しいボード")
+        newBoard.createdAt = existingBoard.createdAt.addingTimeInterval(10)
+        context.insert(newBoard)
+        try context.save()
+
+        var descriptor = FetchDescriptor<Board>(
+            sortBy: [SortDescriptor(\Board.createdAt, order: .forward)]
+        )
+        let boards = try context.fetch(descriptor)
+
+        #expect(boards.count == 2)
+        #expect(boards[0].title == "既存ボード")
+        #expect(boards[1].title == "新しいボード")
+    }
+
+    @Test func 既存ボードのupdatedAtを更新してもcreatedAt昇順の並び順は変わらない() throws {
+        let container = try makeContainer()
+        let context = ModelContext(container)
+
+        let board1 = Board(title: "古いボード")
+        context.insert(board1)
+
+        let board2 = Board(title: "新しいボード")
+        board2.createdAt = board1.createdAt.addingTimeInterval(1)
+        context.insert(board2)
+        try context.save()
+
+        // 古いボードの updatedAt を最新に更新
+        board1.updatedAt = Date().addingTimeInterval(100)
+        try context.save()
+
+        var descriptor = FetchDescriptor<Board>(
+            sortBy: [SortDescriptor(\Board.createdAt, order: .forward)]
+        )
+        let boards = try context.fetch(descriptor)
+
+        // createdAt 昇順なので、updatedAt に関わらず作成順が維持される
+        #expect(boards[0].title == "古いボード")
+        #expect(boards[1].title == "新しいボード")
+    }
+
     // MARK: - placementsData 直接変更時のキャッシュ無効化
 
     @Test func placementsDataを直接変更した場合もキャッシュが無効化される() throws {


### PR DESCRIPTION
## Summary
- ボード一覧のソート順を `updatedAt` 降順から `createdAt` 昇順に変更
- HomeView・BoardListView 両方の `@Query` を統一的に修正
- ソート順を検証するユニットテスト3件を追加（全222テストパス）

## 変更内容
| ファイル | 変更 |
|---------|------|
| `HomeView.swift` | `@Query` のソートを `createdAt.forward` に変更 |
| `BoardListView.swift` | `@Query` のソートを `createdAt.forward` に変更 |
| `BoardTests.swift` | ソート順テスト3件追加 |

## 修正の理由
`updatedAt` 降順でソートしていたため、新規作成したボードが `updatedAt = Date()` で最新となり、カルーセルの左側（先頭）に表示されていた。`createdAt` 昇順に変更することで、新しいボードは常に右側（末尾）に追加され、既存ボードの編集（`updatedAt` の更新）で並び順が変わることもなくなる。

## Test plan
- [x] BoardTests: ボードが `createdAt` 昇順でソートされるテストがパス
- [x] BoardTests: 新しいボードが末尾に配置されるテストがパス
- [x] BoardTests: `updatedAt` 更新で並び順が変わらないテストがパス
- [x] 全222テストがパス
- [ ] 実機でボード作成→右側に追加されることを確認

Close #112

🤖 Generated with [Claude Code](https://claude.com/claude-code)