### PR TITLE
fix: シールライブラリの最下段がタブバーと被る問題を修正

### DIFF
--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -223,8 +223,8 @@ struct StickerLibraryView: View {
                 }
             }
             .padding(20)
-            .padding(.bottom, 80)
         }
+        .safeAreaPadding(.bottom, 80)
     }
 
     private func boardsUsing(_ sticker: Sticker) -> [Board] {


### PR DESCRIPTION
## Summary
- シールライブラリ（StickerLibraryView）のScrollViewコンテンツにボトムパディング（80pt）を追加
- フローティングタブバーに隠れていた最下段のシールが操作可能に

## Test plan
- [ ] ライブラリにシールを多数追加し、最下段までスクロールしてタブバーと被らないことを確認
- [ ] 最下段のシールをタップしてプレビューが正常に表示されることを確認
- [ ] 長押しコンテキストメニューが最下段でも正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)