### PR TITLE
feat: largeウィジェット専用スナップショットを生成してウィジェット全体に表示

### DIFF
--- a/Shared/SharedBoardMetadata.swift
+++ b/Shared/SharedBoardMetadata.swift
@@ -7,4 +7,22 @@ struct SharedBoardMetadata: Codable, Sendable {
     let stickerCount: Int
     let updatedAt: Date
     let snapshotFileName: String
+    /// largeウィジェット専用スナップショットのファイル名（nil = 未生成）
+    var largeSnapshotFileName: String?
+
+    init(
+        id: String,
+        title: String,
+        stickerCount: Int,
+        updatedAt: Date,
+        snapshotFileName: String,
+        largeSnapshotFileName: String? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.stickerCount = stickerCount
+        self.updatedAt = updatedAt
+        self.snapshotFileName = snapshotFileName
+        self.largeSnapshotFileName = largeSnapshotFileName
+    }
 }

--- a/StickerBoard/Services/WidgetDataSyncService.swift
+++ b/StickerBoard/Services/WidgetDataSyncService.swift
@@ -66,7 +66,8 @@ enum WidgetDataSyncService {
             title: title,
             stickerCount: stickerCount,
             updatedAt: updatedAt,
-            snapshotFileName: "\(boardId.uuidString).jpg"
+            snapshotFileName: "\(boardId.uuidString).jpg",
+            largeSnapshotFileName: "\(boardId.uuidString)_large.jpg"
         )
     }
 
@@ -119,6 +120,7 @@ enum WidgetDataSyncService {
         stickerCount: Int,
         updatedAt: Date,
         snapshotImage: UIImage,
+        largeSnapshotImage: UIImage? = nil,
         allBoardsMetadata: [SharedBoardMetadata]
     ) {
         guard let snapshotsDir = snapshotsURL,
@@ -128,9 +130,13 @@ enum WidgetDataSyncService {
         }
 
         let snapshotURL = snapshotsDir.appendingPathComponent("\(boardId.uuidString).jpg")
+        let largeSnapshotURL = snapshotsDir.appendingPathComponent("\(boardId.uuidString)_large.jpg")
 
         do {
             try saveSnapshot(snapshotImage, to: snapshotURL)
+            if let largeImage = largeSnapshotImage {
+                try saveSnapshot(largeImage, to: largeSnapshotURL)
+            }
             try writeMetadataJSON(allBoardsMetadata, to: metaURL)
             WidgetCenter.shared.reloadTimelines(ofKind: SharedWidgetConstants.widgetKind)
         } catch {
@@ -161,7 +167,9 @@ enum WidgetDataSyncService {
         }
 
         let snapshotURL = snapshotsDir.appendingPathComponent("\(boardId.uuidString).jpg")
+        let largeSnapshotURL = snapshotsDir.appendingPathComponent("\(boardId.uuidString)_large.jpg")
         deleteSnapshot(at: snapshotURL)
+        deleteSnapshot(at: largeSnapshotURL)
 
         do {
             try writeMetadataJSON(remainingMetadata, to: metaURL)

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -785,7 +785,8 @@ struct BoardSnapshotView: View {
     /// シール位置・サイズのスケール係数（renderSize に合わせて内容を拡大縮小する）
     private var positionScale: CGFloat {
         guard let rs = renderSize, size.width > 0, size.height > 0 else { return 1.0 }
-        // 幅・高さのうち大きい方のスケールを採用してウィジェット領域を埋める
+        // max() を採用してウィジェット領域を横幅いっぱいに埋める（scaledToFill）。
+        // キャンバスが縦長の場合、縦方向の中央部分だけがウィジェットに収まる（center-crop）。
         return max(rs.width / size.width, rs.height / size.height)
     }
 

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -646,6 +646,7 @@ struct BoardEditorView: View {
             // キャンセル確認
             guard !Task.isCancelled else { return }
 
+            // 通常スナップショット（medium ウィジェット・フォールバック用）
             let snapshotView = BoardSnapshotView(
                 placements: currentPlacements,
                 size: currentCanvasSize,
@@ -663,12 +664,29 @@ struct BoardEditorView: View {
                 return
             }
 
+            // large ウィジェット専用スナップショット（364×382 pt）
+            let largeWidgetSize = CGSize(width: 364, height: 382)
+            let largeSnapshotView = BoardSnapshotView(
+                placements: currentPlacements,
+                size: currentCanvasSize,
+                renderSize: largeWidgetSize,
+                backgroundConfig: currentBgConfig,
+                customBackgroundImage: currentCustomBgImage,
+                showWatermark: false
+            )
+            let largeRenderer = await ImageRenderer(content: largeSnapshotView)
+            await MainActor.run { largeRenderer.scale = 2.0 }
+            let largeImage = await largeRenderer.uiImage
+
+            guard !Task.isCancelled else { return }
+
             WidgetDataSyncService.syncBoard(
                 boardId: boardId,
                 title: boardTitle,
                 stickerCount: stickerCount,
                 updatedAt: boardUpdatedAt,
                 snapshotImage: image,
+                largeSnapshotImage: largeImage,
                 allBoardsMetadata: allMetadata
             )
         }
@@ -753,10 +771,23 @@ private struct QuickPickThumbnail: View {
 
 struct BoardSnapshotView: View {
     let placements: [StickerPlacement]
+    /// エディタのキャンバスサイズ（シール位置の基準）
     let size: CGSize
+    /// ウィジェット用の出力サイズ（nil = size をそのまま使用）
+    var renderSize: CGSize?
     var backgroundConfig: BackgroundPatternConfig = .default
     var customBackgroundImage: UIImage?
     var showWatermark: Bool = false
+
+    /// 実際の描画サイズ
+    private var effectiveSize: CGSize { renderSize ?? size }
+
+    /// シール位置・サイズのスケール係数（renderSize に合わせて内容を拡大縮小する）
+    private var positionScale: CGFloat {
+        guard let rs = renderSize, size.width > 0, size.height > 0 else { return 1.0 }
+        // 幅・高さのうち大きい方のスケールを採用してウィジェット領域を埋める
+        return max(rs.width / size.width, rs.height / size.height)
+    }
 
     var body: some View {
         ZStack {
@@ -767,11 +798,11 @@ struct BoardSnapshotView: View {
                     Image(uiImage: displayImage)
                         .resizable()
                         .scaledToFit()
-                        .frame(width: 120, height: 120)
+                        .frame(width: 120 * positionScale, height: 120 * positionScale)
                         .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
                         .scaleEffect(placement.scale)
                         .rotationEffect(.radians(placement.rotation))
-                        .offset(x: placement.positionX, y: placement.positionY)
+                        .offset(x: placement.positionX * positionScale, y: placement.positionY * positionScale)
                 }
             }
 
@@ -798,7 +829,7 @@ struct BoardSnapshotView: View {
                 }
             }
         }
-        .frame(width: size.width, height: size.height)
+        .frame(width: effectiveSize.width, height: effectiveSize.height)
         .clipped()
     }
 }

--- a/StickerBoardTests/WidgetDataSyncServiceTests.swift
+++ b/StickerBoardTests/WidgetDataSyncServiceTests.swift
@@ -37,6 +37,18 @@ struct WidgetDataSyncServiceTests {
         #expect(metadata.title == "空ボード")
     }
 
+    @Test func generateMetadataでlargeSnapshotFileNameが正しく生成される() {
+        let boardId = UUID()
+        let metadata = WidgetDataSyncService.generateMetadata(
+            boardId: boardId,
+            title: "テストボード",
+            stickerCount: 3,
+            updatedAt: Date()
+        )
+
+        #expect(metadata.largeSnapshotFileName == "\(boardId.uuidString)_large.jpg")
+    }
+
     // MARK: - メタデータJSON書き出し・読み込み
 
     @Test func メタデータJSONの書き出しと読み込みが往復できる() throws {

--- a/StickerBoardTests/WidgetModelsTests.swift
+++ b/StickerBoardTests/WidgetModelsTests.swift
@@ -80,4 +80,66 @@ struct WidgetModelsTests {
         #expect(decoded.stickerCount == 0)
         #expect(decoded.title == "空のボード")
     }
+
+    // MARK: - largeSnapshotFileName
+
+    @Test func largeSnapshotFileNameがエンコード・デコードできる() throws {
+        let id = UUID()
+        let metadata = SharedBoardMetadata(
+            id: id.uuidString,
+            title: "テストボード",
+            stickerCount: 3,
+            updatedAt: Date(),
+            snapshotFileName: "\(id.uuidString).jpg",
+            largeSnapshotFileName: "\(id.uuidString)_large.jpg"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SharedBoardMetadata.self, from: data)
+
+        #expect(decoded.largeSnapshotFileName == "\(id.uuidString)_large.jpg")
+    }
+
+    @Test func largeSnapshotFileNameがない古いJSONはnilとしてデコードされる() throws {
+        // largeSnapshotFileName を含まない旧フォーマットのJSON
+        let oldJSON = """
+        {
+            "id": "AAAAAAAA-0000-0000-0000-000000000001",
+            "title": "古いボード",
+            "stickerCount": 2,
+            "updatedAt": "2025-01-01T00:00:00Z",
+            "snapshotFileName": "AAAAAAAA-0000-0000-0000-000000000001.jpg"
+        }
+        """.data(using: .utf8)!
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(SharedBoardMetadata.self, from: oldJSON)
+
+        #expect(decoded.largeSnapshotFileName == nil)
+        #expect(decoded.title == "古いボード")
+    }
+
+    @Test func largeSnapshotFileNameがnilの場合はJSONにキーが含まれない() throws {
+        let metadata = SharedBoardMetadata(
+            id: UUID().uuidString,
+            title: "テストボード",
+            stickerCount: 1,
+            updatedAt: Date(),
+            snapshotFileName: "board.jpg"
+        )
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(metadata)
+
+        let jsonObject = try JSONSerialization.jsonObject(with: data) as? [String: Any]
+        // nil の場合はキーが含まれないこと（decodeIfPresent を使うため）
+        #expect(jsonObject?["largeSnapshotFileName"] == nil)
+    }
 }

--- a/StickerBoardWidget/BoardShowcase/BoardShowcaseView.swift
+++ b/StickerBoardWidget/BoardShowcase/BoardShowcaseView.swift
@@ -15,7 +15,7 @@ struct BoardShowcaseMediumView: View {
 
                     Image(uiImage: image)
                         .resizable()
-                        .scaledToFit()
+                        .scaledToFill()
                         .frame(width: geo.size.width, height: geo.size.height)
                         .clipped()
                 }
@@ -54,17 +54,19 @@ struct BoardShowcaseLargeView: View {
     let entry: BoardShowcaseEntry
 
     var body: some View {
-        if let image = entry.snapshotImage {
+        // largeSnapshotImage が存在する場合はそちらを優先（364×382 で生成済み）
+        if let image = entry.largeSnapshotImage ?? entry.snapshotImage {
             GeometryReader { geo in
                 ZStack {
                     // ボードの背景色でウィジェット全体を塗りつぶし
                     Color(hex: 0xFAF0DE)
 
-                    // ボード全体を表示（切り取らない）
+                    // ウィジェット全体を埋めるようにスケールし、はみ出した部分はクリップ
                     Image(uiImage: image)
                         .resizable()
-                        .scaledToFit()
+                        .scaledToFill()
                         .frame(width: geo.size.width, height: geo.size.height)
+                        .clipped()
                 }
                 .overlay(alignment: .bottomLeading) {
                     HStack(alignment: .bottom) {

--- a/StickerBoardWidget/BoardShowcase/BoardShowcaseWidget.swift
+++ b/StickerBoardWidget/BoardShowcase/BoardShowcaseWidget.swift
@@ -9,6 +9,8 @@ struct BoardShowcaseEntry: TimelineEntry {
     let boardTitle: String
     let stickerCount: Int
     let snapshotImage: UIImage?
+    /// largeウィジェット専用スナップショット（nil の場合は snapshotImage にフォールバック）
+    let largeSnapshotImage: UIImage?
 }
 
 // MARK: - Timeline Provider
@@ -23,7 +25,8 @@ struct BoardShowcaseProvider: AppIntentTimelineProvider {
             boardId: nil,
             boardTitle: "シールボード",
             stickerCount: 0,
-            snapshotImage: nil
+            snapshotImage: nil,
+            largeSnapshotImage: nil
         )
     }
 
@@ -43,12 +46,14 @@ struct BoardShowcaseProvider: AppIntentTimelineProvider {
             // ボード未選択時: 最初のボードをデフォルト表示
             if let first = WidgetDataManager.loadAllMetadata().first {
                 let image = WidgetDataManager.loadSnapshot(fileName: first.snapshotFileName)
+                let largeImage = first.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
                 return BoardShowcaseEntry(
                     date: Date(),
                     boardId: first.id,
                     boardTitle: first.title,
                     stickerCount: first.stickerCount,
-                    snapshotImage: image
+                    snapshotImage: image,
+                    largeSnapshotImage: largeImage
                 )
             }
             return BoardShowcaseEntry(
@@ -56,19 +61,22 @@ struct BoardShowcaseProvider: AppIntentTimelineProvider {
                 boardId: nil,
                 boardTitle: "シールボード",
                 stickerCount: 0,
-                snapshotImage: nil
+                snapshotImage: nil,
+                largeSnapshotImage: nil
             )
         }
 
         let metadata = WidgetDataManager.metadata(for: board.id)
         let image = metadata.flatMap { WidgetDataManager.loadSnapshot(fileName: $0.snapshotFileName) }
+        let largeImage = metadata?.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
 
         return BoardShowcaseEntry(
             date: Date(),
             boardId: board.id,
             boardTitle: metadata?.title ?? board.title,
             stickerCount: metadata?.stickerCount ?? board.stickerCount,
-            snapshotImage: image
+            snapshotImage: image,
+            largeSnapshotImage: largeImage
         )
     }
 }

--- a/StickerBoardWidget/BoardShowcase/BoardShowcaseWidget.swift
+++ b/StickerBoardWidget/BoardShowcase/BoardShowcaseWidget.swift
@@ -31,22 +31,25 @@ struct BoardShowcaseProvider: AppIntentTimelineProvider {
     }
 
     func snapshot(for configuration: BoardShowcaseConfigIntent, in context: Context) async -> BoardShowcaseEntry {
-        makeEntry(for: configuration)
+        makeEntry(for: configuration, isLarge: context.family == .systemLarge)
     }
 
     func timeline(for configuration: BoardShowcaseConfigIntent, in context: Context) async -> Timeline<BoardShowcaseEntry> {
-        let entry = makeEntry(for: configuration)
+        let entry = makeEntry(for: configuration, isLarge: context.family == .systemLarge)
         // ウィジェットはアプリ側から WidgetCenter.reloadTimelines で更新されるため、
         // タイムラインポリシーは .never を使用
         return Timeline(entries: [entry], policy: .never)
     }
 
-    private func makeEntry(for configuration: BoardShowcaseConfigIntent) -> BoardShowcaseEntry {
+    /// - Parameter isLarge: largeサイズの場合は専用スナップショットを読み込む（メモリ最適化）
+    private func makeEntry(for configuration: BoardShowcaseConfigIntent, isLarge: Bool) -> BoardShowcaseEntry {
         guard let board = configuration.board else {
             // ボード未選択時: 最初のボードをデフォルト表示
             if let first = WidgetDataManager.loadAllMetadata().first {
                 let image = WidgetDataManager.loadSnapshot(fileName: first.snapshotFileName)
-                let largeImage = first.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
+                let largeImage = isLarge
+                    ? first.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
+                    : nil
                 return BoardShowcaseEntry(
                     date: Date(),
                     boardId: first.id,
@@ -68,7 +71,9 @@ struct BoardShowcaseProvider: AppIntentTimelineProvider {
 
         let metadata = WidgetDataManager.metadata(for: board.id)
         let image = metadata.flatMap { WidgetDataManager.loadSnapshot(fileName: $0.snapshotFileName) }
-        let largeImage = metadata?.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
+        let largeImage = isLarge
+            ? metadata?.largeSnapshotFileName.flatMap { WidgetDataManager.loadSnapshot(fileName: $0) }
+            : nil
 
         return BoardShowcaseEntry(
             date: Date(),


### PR DESCRIPTION
PR #199 に統合済みのためクローズ。\n\nPR #198 の変更内容（large スナップショット生成）は `feat/issue-195-widget-board-type` ブランチにマージされました。