### PR TITLE
feat: ボード共有機能を追加（Issue #204）

### DIFF
--- a/StickerBoard/Localizable.xcstrings
+++ b/StickerBoard/Localizable.xcstrings
@@ -2396,6 +2396,16 @@
         }
       }
     },
+    "共有" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share"
+          }
+        }
+      }
+    },
     "写真に保存" : {
       "localizations" : {
         "en" : {

--- a/StickerBoard/Services/BoardShareService.swift
+++ b/StickerBoard/Services/BoardShareService.swift
@@ -1,0 +1,101 @@
+import SwiftUI
+import os
+
+/// ボードのSNSシェア機能を提供するサービス
+@MainActor
+enum BoardShareService {
+    private static let logger = Logger(subsystem: "com.tebasaki.StickerBoard", category: "Share")
+
+    /// Board モデルから直接シェアシートを表示する（ホーム・ボード一覧から利用）
+    static func share(_ board: Board, displayScale: CGFloat) {
+        let customBackgroundImage = loadCustomBackgroundImage(for: board)
+        presentShareSheet(
+            placements: board.placements,
+            canvasSize: estimatedCanvasSize(for: board),
+            backgroundConfig: board.backgroundPattern,
+            customBackgroundImage: customBackgroundImage,
+            displayScale: displayScale
+        )
+    }
+
+    /// エディタのキャンバスサイズを使ってシェアシートを表示する（ボードエディタから利用）
+    static func share(placements: [StickerPlacement], canvasSize: CGSize, backgroundConfig: BackgroundPatternConfig, customBackgroundImage: UIImage?, displayScale: CGFloat) {
+        presentShareSheet(
+            placements: placements,
+            canvasSize: canvasSize,
+            backgroundConfig: backgroundConfig,
+            customBackgroundImage: customBackgroundImage,
+            displayScale: displayScale
+        )
+    }
+
+    // MARK: - Private
+
+    private static func presentShareSheet(placements: [StickerPlacement], canvasSize: CGSize, backgroundConfig: BackgroundPatternConfig, customBackgroundImage: UIImage?, displayScale: CGFloat) {
+        let content = BoardSnapshotView(
+            placements: placements,
+            size: canvasSize,
+            backgroundConfig: backgroundConfig,
+            customBackgroundImage: customBackgroundImage,
+            showWatermark: !SubscriptionManager.shared.isProUser
+        )
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = displayScale
+
+        guard let image = renderer.uiImage else {
+            logger.error("presentShareSheet: ImageRenderer returned nil (canvasSize=\(String(describing: canvasSize)))")
+            return
+        }
+
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let rootVC = windowScene.keyWindow?.rootViewController else {
+            logger.error("presentShareSheet: Could not find foreground window scene or rootViewController")
+            return
+        }
+
+        // 最前面のVCを辿ってpresent（既存のシートやアラートと競合しないよう）
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+
+        if let popover = activityVC.popoverPresentationController {
+            let bounds = windowScene.screen.bounds
+            popover.sourceView = topVC.view
+            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        topVC.present(activityVC, animated: true)
+    }
+
+    /// Board の写真背景画像を読み込む（ファイル未発見時はログを出して nil を返す）
+    private static func loadCustomBackgroundImage(for board: Board) -> UIImage? {
+        guard board.backgroundPattern.patternType == .custom,
+              let fileName = board.backgroundPattern.customImageFileName else { return nil }
+        let image = BackgroundImageStorage.load(fileName: fileName)
+        if image == nil {
+            logger.error("loadCustomBackgroundImage: Failed to load '\(fileName)' for board \(board.id.uuidString)")
+        }
+        return image
+    }
+
+    /// BoardEditorView のキャンバスサイズを近似する（padding 24pt×2、ボードタイプ別アスペクト比）
+    static func estimatedCanvasSize(for board: Board) -> CGSize {
+        let bounds = AppTheme.screenBounds
+        let width = bounds.width - 48
+        switch board.boardType {
+        case .widgetLarge:
+            return CGSize(width: width, height: width / BoardType.widgetLargeAspectRatio)
+        case .widgetMedium:
+            return CGSize(width: width, height: width / BoardType.widgetMediumAspectRatio)
+        case .standard:
+            return CGSize(width: width, height: bounds.height - 200)
+        }
+    }
+}

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -762,28 +762,13 @@ struct BoardEditorView: View {
     // MARK: - SNSシェア
 
     private func shareBoardAsImage() {
-        let content = BoardSnapshotView(placements: sortedPlacements, size: canvasSize, backgroundConfig: backgroundConfig, customBackgroundImage: customBackgroundImage, showWatermark: !SubscriptionManager.shared.isProUser)
-
-        let renderer = ImageRenderer(content: content)
-        renderer.scale = displayScale
-
-        guard let image = renderer.uiImage else { return }
-
-        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
-
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive }),
-              let rootVC = windowScene.keyWindow?.rootViewController else { return }
-
-        if let popover = activityVC.popoverPresentationController {
-            let bounds = windowScene.screen.bounds
-            popover.sourceView = rootVC.view
-            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-
-        rootVC.present(activityVC, animated: true)
+        BoardShareService.share(
+            placements: sortedPlacements,
+            canvasSize: canvasSize,
+            backgroundConfig: backgroundConfig,
+            customBackgroundImage: customBackgroundImage,
+            displayScale: displayScale
+        )
     }
 
     // MARK: - 画像として保存

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -118,7 +118,17 @@ struct BoardEditorView: View {
         .toolbarBackground(AppTheme.editorBackground, for: .navigationBar)
         .toolbarBackground(.visible, for: .navigationBar)
         .toolbar {
-            ToolbarItem(placement: .primaryAction) {
+            ToolbarItemGroup(placement: .primaryAction) {
+                Button {
+                    shareBoardAsImage()
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(placements.isEmpty ? AppTheme.textTertiary : AppTheme.accent)
+                }
+                .accessibilityLabel(String(localized: "共有"))
+                .disabled(placements.isEmpty)
+
                 Button {
                     showingSaveConfirmation = true
                 } label: {
@@ -126,7 +136,7 @@ struct BoardEditorView: View {
                         .font(.system(size: 15, weight: .medium))
                         .foregroundStyle(placements.isEmpty ? AppTheme.textTertiary : AppTheme.accent)
                 }
-                .accessibilityLabel("写真に保存")
+                .accessibilityLabel(String(localized: "写真に保存"))
                 .disabled(placements.isEmpty)
             }
         }
@@ -747,6 +757,33 @@ struct BoardEditorView: View {
         } else {
             customBackgroundImage = nil
         }
+    }
+
+    // MARK: - SNSシェア
+
+    private func shareBoardAsImage() {
+        let content = BoardSnapshotView(placements: sortedPlacements, size: canvasSize, backgroundConfig: backgroundConfig, customBackgroundImage: customBackgroundImage, showWatermark: !SubscriptionManager.shared.isProUser)
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = displayScale
+
+        guard let image = renderer.uiImage else { return }
+
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let rootVC = windowScene.keyWindow?.rootViewController else { return }
+
+        if let popover = activityVC.popoverPresentationController {
+            let bounds = windowScene.screen.bounds
+            popover.sourceView = rootVC.view
+            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        rootVC.present(activityVC, animated: true)
     }
 
     // MARK: - 画像として保存

--- a/StickerBoard/Views/Board/BoardListView.swift
+++ b/StickerBoard/Views/Board/BoardListView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct BoardListView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.displayScale) private var displayScale
     @Query(sort: \Board.createdAt, order: .forward) private var boards: [Board]
 
     @State private var showingNewBoard = false
@@ -110,6 +111,11 @@ struct BoardListView: View {
                     }
                     .buttonStyle(.plain)
                     .contextMenu {
+                        Button {
+                            shareBoardAsImage(board)
+                        } label: {
+                            Label("共有", systemImage: "square.and.arrow.up")
+                        }
                         Button(role: .destructive) {
                             boardToDelete = board
                             showingDeleteConfirmation = true
@@ -120,6 +126,62 @@ struct BoardListView: View {
                 }
             }
             .padding(20)
+        }
+    }
+
+    // MARK: - SNSシェア
+
+    /// ボードを画像にレンダリングしてiOSシェアシートを表示する
+    private func shareBoardAsImage(_ board: Board) {
+        let canvasSize = estimatedCanvasSize(for: board)
+        let customBackgroundImage: UIImage? = {
+            guard board.backgroundPattern.patternType == .custom,
+                  let fileName = board.backgroundPattern.customImageFileName else { return nil }
+            return BackgroundImageStorage.load(fileName: fileName)
+        }()
+
+        let content = BoardSnapshotView(
+            placements: board.placements,
+            size: canvasSize,
+            backgroundConfig: board.backgroundPattern,
+            customBackgroundImage: customBackgroundImage,
+            showWatermark: !SubscriptionManager.shared.isProUser
+        )
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = displayScale
+
+        guard let image = renderer.uiImage else { return }
+
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let rootVC = windowScene.keyWindow?.rootViewController else { return }
+
+        if let popover = activityVC.popoverPresentationController {
+            let bounds = windowScene.screen.bounds
+            popover.sourceView = rootVC.view
+            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        rootVC.present(activityVC, animated: true)
+    }
+
+    /// BoardEditorViewのキャンバスサイズを近似する（padding 24pt×2、ボードタイプ別アスペクト比）
+    @MainActor
+    private func estimatedCanvasSize(for board: Board) -> CGSize {
+        let bounds = AppTheme.screenBounds
+        let width = bounds.width - 48
+        switch board.boardType {
+        case .widgetLarge:
+            return CGSize(width: width, height: width / BoardType.widgetLargeAspectRatio)
+        case .widgetMedium:
+            return CGSize(width: width, height: width / BoardType.widgetMediumAspectRatio)
+        case .standard:
+            return CGSize(width: width, height: bounds.height - 200)
         }
     }
 

--- a/StickerBoard/Views/Board/BoardListView.swift
+++ b/StickerBoard/Views/Board/BoardListView.swift
@@ -131,58 +131,8 @@ struct BoardListView: View {
 
     // MARK: - SNSシェア
 
-    /// ボードを画像にレンダリングしてiOSシェアシートを表示する
     private func shareBoardAsImage(_ board: Board) {
-        let canvasSize = estimatedCanvasSize(for: board)
-        let customBackgroundImage: UIImage? = {
-            guard board.backgroundPattern.patternType == .custom,
-                  let fileName = board.backgroundPattern.customImageFileName else { return nil }
-            return BackgroundImageStorage.load(fileName: fileName)
-        }()
-
-        let content = BoardSnapshotView(
-            placements: board.placements,
-            size: canvasSize,
-            backgroundConfig: board.backgroundPattern,
-            customBackgroundImage: customBackgroundImage,
-            showWatermark: !SubscriptionManager.shared.isProUser
-        )
-
-        let renderer = ImageRenderer(content: content)
-        renderer.scale = displayScale
-
-        guard let image = renderer.uiImage else { return }
-
-        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
-
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive }),
-              let rootVC = windowScene.keyWindow?.rootViewController else { return }
-
-        if let popover = activityVC.popoverPresentationController {
-            let bounds = windowScene.screen.bounds
-            popover.sourceView = rootVC.view
-            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-
-        rootVC.present(activityVC, animated: true)
-    }
-
-    /// BoardEditorViewのキャンバスサイズを近似する（padding 24pt×2、ボードタイプ別アスペクト比）
-    @MainActor
-    private func estimatedCanvasSize(for board: Board) -> CGSize {
-        let bounds = AppTheme.screenBounds
-        let width = bounds.width - 48
-        switch board.boardType {
-        case .widgetLarge:
-            return CGSize(width: width, height: width / BoardType.widgetLargeAspectRatio)
-        case .widgetMedium:
-            return CGSize(width: width, height: width / BoardType.widgetMediumAspectRatio)
-        case .standard:
-            return CGSize(width: width, height: bounds.height - 200)
-        }
+        BoardShareService.share(board, displayScale: displayScale)
     }
 
     private func createBoard() {

--- a/StickerBoard/Views/Home/HomeView.swift
+++ b/StickerBoard/Views/Home/HomeView.swift
@@ -3,6 +3,7 @@ import SwiftData
 
 struct HomeView: View {
     @Environment(\.modelContext) private var modelContext
+    @Environment(\.displayScale) private var displayScale
     @Query(sort: \Board.createdAt, order: .forward) private var boards: [Board]
 
     private let newBoardCardID = "new-board"
@@ -228,6 +229,12 @@ struct HomeView: View {
                                     Label("名前を変更", systemImage: "pencil")
                                 }
 
+                                Button {
+                                    shareBoardAsImage(board)
+                                } label: {
+                                    Label("共有", systemImage: "square.and.arrow.up")
+                                }
+
                                 Divider()
 
                                 Button(role: .destructive) {
@@ -419,6 +426,60 @@ struct HomeView: View {
         let board = Board(title: title, boardType: boardType)
         modelContext.insert(board)
         onBoardCreated()
+    }
+
+    // MARK: - SNSシェア
+
+    private func shareBoardAsImage(_ board: Board) {
+        let canvasSize = estimatedCanvasSize(for: board)
+        let customBackgroundImage: UIImage? = {
+            guard board.backgroundPattern.patternType == .custom,
+                  let fileName = board.backgroundPattern.customImageFileName else { return nil }
+            return BackgroundImageStorage.load(fileName: fileName)
+        }()
+
+        let content = BoardSnapshotView(
+            placements: board.placements,
+            size: canvasSize,
+            backgroundConfig: board.backgroundPattern,
+            customBackgroundImage: customBackgroundImage,
+            showWatermark: !SubscriptionManager.shared.isProUser
+        )
+
+        let renderer = ImageRenderer(content: content)
+        renderer.scale = displayScale
+
+        guard let image = renderer.uiImage else { return }
+
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let rootVC = windowScene.keyWindow?.rootViewController else { return }
+
+        if let popover = activityVC.popoverPresentationController {
+            let bounds = windowScene.screen.bounds
+            popover.sourceView = rootVC.view
+            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        rootVC.present(activityVC, animated: true)
+    }
+
+    @MainActor
+    private func estimatedCanvasSize(for board: Board) -> CGSize {
+        let bounds = AppTheme.screenBounds
+        let width = bounds.width - 48
+        switch board.boardType {
+        case .widgetLarge:
+            return CGSize(width: width, height: width / BoardType.widgetLargeAspectRatio)
+        case .widgetMedium:
+            return CGSize(width: width, height: width / BoardType.widgetMediumAspectRatio)
+        case .standard:
+            return CGSize(width: width, height: bounds.height - 200)
+        }
     }
 
     private func renameBoard() {

--- a/StickerBoard/Views/Home/HomeView.swift
+++ b/StickerBoard/Views/Home/HomeView.swift
@@ -431,55 +431,7 @@ struct HomeView: View {
     // MARK: - SNSシェア
 
     private func shareBoardAsImage(_ board: Board) {
-        let canvasSize = estimatedCanvasSize(for: board)
-        let customBackgroundImage: UIImage? = {
-            guard board.backgroundPattern.patternType == .custom,
-                  let fileName = board.backgroundPattern.customImageFileName else { return nil }
-            return BackgroundImageStorage.load(fileName: fileName)
-        }()
-
-        let content = BoardSnapshotView(
-            placements: board.placements,
-            size: canvasSize,
-            backgroundConfig: board.backgroundPattern,
-            customBackgroundImage: customBackgroundImage,
-            showWatermark: !SubscriptionManager.shared.isProUser
-        )
-
-        let renderer = ImageRenderer(content: content)
-        renderer.scale = displayScale
-
-        guard let image = renderer.uiImage else { return }
-
-        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
-
-        guard let windowScene = UIApplication.shared.connectedScenes
-            .compactMap({ $0 as? UIWindowScene })
-            .first(where: { $0.activationState == .foregroundActive }),
-              let rootVC = windowScene.keyWindow?.rootViewController else { return }
-
-        if let popover = activityVC.popoverPresentationController {
-            let bounds = windowScene.screen.bounds
-            popover.sourceView = rootVC.view
-            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
-            popover.permittedArrowDirections = []
-        }
-
-        rootVC.present(activityVC, animated: true)
-    }
-
-    @MainActor
-    private func estimatedCanvasSize(for board: Board) -> CGSize {
-        let bounds = AppTheme.screenBounds
-        let width = bounds.width - 48
-        switch board.boardType {
-        case .widgetLarge:
-            return CGSize(width: width, height: width / BoardType.widgetLargeAspectRatio)
-        case .widgetMedium:
-            return CGSize(width: width, height: width / BoardType.widgetMediumAspectRatio)
-        case .standard:
-            return CGSize(width: width, height: bounds.height - 200)
-        }
+        BoardShareService.share(board, displayScale: displayScale)
     }
 
     private func renameBoard() {


### PR DESCRIPTION
## 概要

作成したボードをSNSなどに共有できる導線を追加します。
Issue #204 の基本シェア機能の実装です。

## 変更内容

### 追加した共有導線

| 場所 | 操作 | 動作 |
|------|------|------|
| ホーム画面 | ボードカードの3点リーダー →「共有」 | シェアシート表示 |
| ボード一覧 | カードを長押し → 「共有」 | シェアシート表示 |
| ボードエディタ | ナビバー右上の `↑` ボタン | シェアシート表示 |

### 実装詳細

- `UIActivityViewController` でiOS標準シェアシートを呼び出す
- `BoardSnapshotView` + `ImageRenderer` でボードを画像としてレンダリングしてシェア
- Proユーザー以外はウォーターマーク（ロゴ）入りで共有
- iPad対応（popoverのanchor設定済み）
- ローカライズ対応（ja: 共有 / en: Share）

## テスト手順

- [ ] ホーム画面のボードカード3点リーダーから「共有」をタップしてシェアシートが開くか確認
- [ ] ボード一覧でカードを長押しして「共有」からシェアシートが開くか確認
- [ ] ボードエディタのナビバー `↑` ボタンでシェアシートが開くか確認
- [ ] シールが配置されたボードを共有したとき、画像にシールが反映されているか確認
- [ ] Proユーザー以外でウォーターマークが入るか確認

## 関連 Issue

Closes #204（将来の「シェアで限定コンテンツ解放」機能の前提実装）

🤖 Generated with [Claude Code](https://claude.com/claude-code)