### PR TITLE
feat: シール単体の共有・写真保存機能を追加（#202）

### DIFF
--- a/StickerBoard.xcodeproj/project.pbxproj
+++ b/StickerBoard.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		8834A7A836ECA4320FA81370 /* MultiStickerSelectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E24D931F5239EB34E8311209 /* MultiStickerSelectionView.swift */; };
 		89ABB4288877EB39D9B22BD7 /* StickerBoardWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 5FF690E061C9B4C41740689C /* StickerBoardWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		8A0BE5317CBBA4F680A00C60 /* HolographicEffectModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3834BB169411132599770224 /* HolographicEffectModifier.swift */; };
+		8F02D30B673FB50BF6AD2D84 /* StickerShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38FDFEFAB3742B009EA8F50B /* StickerShareService.swift */; };
 		91B6DD4664FB19D95590BC04 /* SubscriptionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9FFB83566A2BC0906338F77F /* SubscriptionManager.swift */; };
 		91F9C1053CEBEFD48083BA55 /* BoardShowcaseIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FA79057C282BD3CE501F363 /* BoardShowcaseIntent.swift */; };
 		946C3EF198BC305C48293848 /* StickerCaptureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D878D128C4599B9F13AD702 /* StickerCaptureView.swift */; };
@@ -94,6 +95,7 @@
 		D60EA71E7EF817ABF7C9D220 /* BoardShareServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D5AF5A572900934DD45A38A /* BoardShareServiceTests.swift */; };
 		D741DBFD1F632B3907AE5F50 /* ImageCacheManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1211D3F280555E23A6562B3 /* ImageCacheManager.swift */; };
 		D8FB4DBA0430E40FCFD3F87F /* StickerFilterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A215C34AD5CB548459350358 /* StickerFilterTests.swift */; };
+		D9F5D0B1D91568E3331B22EE /* StickerShareServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F8EB1C52BF7B32985F173FC /* StickerShareServiceTests.swift */; };
 		DB745BDCC883E3A46CBFB7C1 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C9A3FC5FB8145015E1952AD /* MainTabView.swift */; };
 		E0546E3252F1E756FEC85DA1 /* StickerPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B03A91B141329E13EDBEAE9A /* StickerPlacementTests.swift */; };
 		E1E29CF14D41BF97D2C1B6E2 /* ImageStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604CC75026AD20187DC30B3F /* ImageStorageTests.swift */; };
@@ -171,10 +173,12 @@
 		351900E2F8D31C115B9F755A /* UIImageExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIImageExtensionTests.swift; sourceTree = "<group>"; };
 		37C5DFE900836F1D943C5CFB /* BoardListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardListView.swift; sourceTree = "<group>"; };
 		3834BB169411132599770224 /* HolographicEffectModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolographicEffectModifier.swift; sourceTree = "<group>"; };
+		38FDFEFAB3742B009EA8F50B /* StickerShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerShareService.swift; sourceTree = "<group>"; };
 		3AA9B705D7B3675A472439D3 /* WidgetDataSyncService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetDataSyncService.swift; sourceTree = "<group>"; };
 		3D95F00C228CAD698E6DB326 /* MaskDrawingCanvas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskDrawingCanvas.swift; sourceTree = "<group>"; };
 		3DE8FA1873B214DE9520E815 /* AppTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppTheme.swift; sourceTree = "<group>"; };
 		3E3E385C3511299350E1EDC0 /* HolographicAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HolographicAccessibilityTests.swift; sourceTree = "<group>"; };
+		3F8EB1C52BF7B32985F173FC /* StickerShareServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerShareServiceTests.swift; sourceTree = "<group>"; };
 		453EB379EB98A3F0EDA2660F /* BoardAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardAccessibilityTests.swift; sourceTree = "<group>"; };
 		481D3899B8F8B2A414930953 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		4939209FC57BA497E419A77C /* LocalizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalizationTests.swift; sourceTree = "<group>"; };
@@ -402,6 +406,7 @@
 				C94311FE1E30296BB608F927 /* SharedCIContext.swift */,
 				ABCD1438794D34A642F45B93 /* StickerBorderService.swift */,
 				D44F094F53D9CC5028477F0F /* StickerFilterService.swift */,
+				38FDFEFAB3742B009EA8F50B /* StickerShareService.swift */,
 				9FFB83566A2BC0906338F77F /* SubscriptionManager.swift */,
 				3AA9B705D7B3675A472439D3 /* WidgetDataSyncService.swift */,
 			);
@@ -525,6 +530,7 @@
 				A215C34AD5CB548459350358 /* StickerFilterTests.swift */,
 				0B6E414C38C81FDD95EBC2EE /* StickerLibraryAccessibilityTests.swift */,
 				B03A91B141329E13EDBEAE9A /* StickerPlacementTests.swift */,
+				3F8EB1C52BF7B32985F173FC /* StickerShareServiceTests.swift */,
 				BCDBB451BECC869CD24CAF7B /* SubscriptionProductTests.swift */,
 				351900E2F8D31C115B9F755A /* UIImageExtensionTests.swift */,
 				827CF4CCF758CF7D72CCC423 /* WidgetDataSyncServiceTests.swift */,
@@ -729,6 +735,7 @@
 				0144BFC5D2AC9275B5FA6156 /* StickerLibraryView.swift in Sources */,
 				9ADB3E6146D90A1ED01BA205 /* StickerPlacement.swift in Sources */,
 				A9E174752B496F13389C1181 /* StickerPreviewView.swift in Sources */,
+				8F02D30B673FB50BF6AD2D84 /* StickerShareService.swift in Sources */,
 				91B6DD4664FB19D95590BC04 /* SubscriptionManager.swift in Sources */,
 				CB5CDB350C326919C148B630 /* SubscriptionProduct.swift in Sources */,
 				65C2B4E7FEA4EACCD89B17F5 /* WidgetDataSyncService.swift in Sources */,
@@ -772,6 +779,7 @@
 				D8FB4DBA0430E40FCFD3F87F /* StickerFilterTests.swift in Sources */,
 				C4460E2AC4B0A01446BD3666 /* StickerLibraryAccessibilityTests.swift in Sources */,
 				E0546E3252F1E756FEC85DA1 /* StickerPlacementTests.swift in Sources */,
+				D9F5D0B1D91568E3331B22EE /* StickerShareServiceTests.swift in Sources */,
 				55E9EE6723FF659967D5B49F /* SubscriptionProductTests.swift in Sources */,
 				33D1A0E16223FCAC8B67B99B /* UIImageExtensionTests.swift in Sources */,
 				AF1C7EC7EF7362CD7ABA273B /* WidgetDataSyncServiceTests.swift in Sources */,

--- a/StickerBoard/Localizable.xcstrings
+++ b/StickerBoard/Localizable.xcstrings
@@ -2436,6 +2436,46 @@
         }
       }
     },
+    "写真を保存しました" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Saved to Photos"
+          }
+        }
+      }
+    },
+    "フォトライブラリへの保存中にエラーが発生しました。アクセス許可を確認してください。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An error occurred while saving to the photo library. Please check access permissions."
+          }
+        }
+      }
+    },
+    "シール画像をAirDrop・SNS等で共有します" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share the sticker image via AirDrop, social media, etc."
+          }
+        }
+      }
+    },
+    "シール画像をフォトライブラリに保存します" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save the sticker image to your photo library."
+          }
+        }
+      }
+    },
     "写真を切り抜いて\nオリジナルシールを作ろう" : {
       "localizations" : {
         "en" : {

--- a/StickerBoard/Localizable.xcstrings
+++ b/StickerBoard/Localizable.xcstrings
@@ -1264,6 +1264,28 @@
         }
       }
     },
+    "シール画像をAirDrop・SNS等で共有します" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share the sticker image via AirDrop, social media, etc."
+          }
+        }
+      }
+    },
+    "シール画像をフォトライブラリに保存します" : {
+      "extractionState" : "stale",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Save the sticker image to your photo library."
+          }
+        }
+      }
+    },
     "シール追加" : {
       "localizations" : {
         "en" : {
@@ -1624,6 +1646,16 @@
         }
       }
     },
+    "フォトライブラリへの保存中にエラーが発生しました。アクセス許可を確認してください。" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "An error occurred while saving to the photo library. Please check access permissions."
+          }
+        }
+      }
+    },
     "ぷっくり" : {
       "localizations" : {
         "en" : {
@@ -1945,6 +1977,7 @@
       }
     },
     "マスクを再編集" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2336,6 +2369,16 @@
         }
       }
     },
+    "共有" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Share"
+          }
+        }
+      }
+    },
     "再編集" : {
       "localizations" : {
         "en" : {
@@ -2396,16 +2439,6 @@
         }
       }
     },
-    "共有" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share"
-          }
-        }
-      }
-    },
     "写真に保存" : {
       "localizations" : {
         "en" : {
@@ -2442,36 +2475,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Saved to Photos"
-          }
-        }
-      }
-    },
-    "フォトライブラリへの保存中にエラーが発生しました。アクセス許可を確認してください。" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "An error occurred while saving to the photo library. Please check access permissions."
-          }
-        }
-      }
-    },
-    "シール画像をAirDrop・SNS等で共有します" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Share the sticker image via AirDrop, social media, etc."
-          }
-        }
-      }
-    },
-    "シール画像をフォトライブラリに保存します" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Save the sticker image to your photo library."
           }
         }
       }
@@ -2717,6 +2720,16 @@
         }
       }
     },
+    "右回転" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate Right"
+          }
+        }
+      }
+    },
     "合成しています..." : {
       "localizations" : {
         "en" : {
@@ -2833,6 +2846,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Move Left"
+          }
+        }
+      }
+    },
+    "左回転" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rotate Left"
           }
         }
       }

--- a/StickerBoard/Services/StickerShareService.swift
+++ b/StickerBoard/Services/StickerShareService.swift
@@ -1,0 +1,81 @@
+import Photos
+import UIKit
+import os
+
+/// シール単体の共有・写真保存機能を提供するサービス
+@MainActor
+enum StickerShareService {
+    private static let logger = Logger(subsystem: "com.tebasaki.StickerBoard", category: "StickerShare")
+
+    /// シール画像をシェアシートで共有する
+    static func share(_ sticker: Sticker) {
+        Task {
+            await presentShareSheet(for: sticker)
+        }
+    }
+
+    /// シール画像をフォトライブラリに保存する
+    /// - Returns: 保存成功時は true、失敗時は false
+    static func saveToPhotos(_ sticker: Sticker) async -> Bool {
+        guard let image = await loadImage(for: sticker) else {
+            logger.error("saveToPhotos: Failed to load image for sticker \(sticker.imageFileName)")
+            return false
+        }
+
+        let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
+        guard status == .authorized else {
+            logger.warning("saveToPhotos: Photo library authorization denied (status=\(status.rawValue))")
+            return false
+        }
+
+        do {
+            try await PHPhotoLibrary.shared().performChanges {
+                PHAssetChangeRequest.creationRequestForAsset(from: image)
+            }
+            return true
+        } catch {
+            logger.error("saveToPhotos: Failed to save to photo library: \(error)")
+            return false
+        }
+    }
+
+    // MARK: - Private
+
+    private static func presentShareSheet(for sticker: Sticker) async {
+        guard let image = await loadImage(for: sticker) else {
+            logger.error("presentShareSheet: Failed to load image for sticker \(sticker.imageFileName)")
+            return
+        }
+
+        let activityVC = UIActivityViewController(activityItems: [image], applicationActivities: nil)
+
+        guard let windowScene = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene })
+            .first(where: { $0.activationState == .foregroundActive }),
+              let rootVC = windowScene.keyWindow?.rootViewController else {
+            logger.error("presentShareSheet: Could not find foreground window scene or rootViewController")
+            return
+        }
+
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController {
+            topVC = presented
+        }
+
+        if let popover = activityVC.popoverPresentationController {
+            let bounds = windowScene.screen.bounds
+            popover.sourceView = topVC.view
+            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.permittedArrowDirections = []
+        }
+
+        topVC.present(activityVC, animated: true)
+    }
+
+    private static func loadImage(for sticker: Sticker) async -> UIImage? {
+        let fileName = sticker.imageFileName
+        return await Task.detached {
+            ImageStorage.load(fileName: fileName)
+        }.value
+    }
+}

--- a/StickerBoard/Services/StickerShareService.swift
+++ b/StickerBoard/Services/StickerShareService.swift
@@ -23,7 +23,7 @@ enum StickerShareService {
         }
 
         let status = await PHPhotoLibrary.requestAuthorization(for: .addOnly)
-        guard status == .authorized else {
+        guard status == .authorized || status == .limited else {
             logger.warning("saveToPhotos: Photo library authorization denied (status=\(status.rawValue))")
             return false
         }
@@ -63,9 +63,12 @@ enum StickerShareService {
         }
 
         if let popover = activityVC.popoverPresentationController {
-            let bounds = windowScene.screen.bounds
             popover.sourceView = topVC.view
-            popover.sourceRect = CGRect(x: bounds.midX, y: bounds.midY, width: 0, height: 0)
+            popover.sourceRect = CGRect(
+                x: topVC.view.bounds.midX,
+                y: topVC.view.bounds.midY,
+                width: 0, height: 0
+            )
             popover.permittedArrowDirections = []
         }
 

--- a/StickerBoard/Services/StickerShareService.swift
+++ b/StickerBoard/Services/StickerShareService.swift
@@ -76,9 +76,6 @@ enum StickerShareService {
     }
 
     private static func loadImage(for sticker: Sticker) async -> UIImage? {
-        let fileName = sticker.imageFileName
-        return await Task.detached {
-            ImageStorage.load(fileName: fileName)
-        }.value
+        return await ImageStorage.loadAsync(fileName: sticker.imageFileName)
     }
 }

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -24,6 +24,8 @@ struct StickerLibraryView: View {
     @State private var thumbnailRefreshID = UUID()
     @State private var showRotateError = false
     @State private var sortNewest = true
+    @State private var showSaveToPhotosResult = false
+    @State private var saveToPhotosSuccess = false
     @Namespace private var previewNamespace
     let refreshTrigger: UUID
     var onAddSticker: () -> Void = {}
@@ -74,6 +76,16 @@ struct StickerLibraryView: View {
             } message: {
                 Text("シール画像の読み込みに失敗しました。画像が破損している可能性があります。")
             }
+            .alert(
+                saveToPhotosSuccess ? "写真を保存しました" : "保存に失敗しました",
+                isPresented: $showSaveToPhotosResult
+            ) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                if !saveToPhotosSuccess {
+                    Text("フォトライブラリへの保存中にエラーが発生しました。アクセス許可を確認してください。")
+                }
+            }
     }
 
     private var libraryContent: some View {
@@ -95,7 +107,9 @@ struct StickerLibraryView: View {
                             withAnimation(.spring(duration: 0.35, bounce: 0.2)) { previewSticker = nil }
                             startMaskEdit(sticker)
                         },
-                        onRotate: { clockwise in rotateSticker(sticker, clockwise: clockwise) }
+                        onRotate: { clockwise in rotateSticker(sticker, clockwise: clockwise) },
+                        onShare: { StickerShareService.share(sticker) },
+                        onSaveToPhotos: { saveSticker(sticker) }
                     )
                 }
             }
@@ -248,6 +262,17 @@ struct StickerLibraryView: View {
                             .accessibilityHint("タップしてプレビューを表示")
                             .contextMenu {
                                 Button {
+                                    StickerShareService.share(sticker)
+                                } label: {
+                                    Label("共有", systemImage: "square.and.arrow.up")
+                                }
+                                Button {
+                                    saveSticker(sticker)
+                                } label: {
+                                    Label("写真に保存", systemImage: "square.and.arrow.down")
+                                }
+                                Divider()
+                                Button {
                                     rotateSticker(sticker, clockwise: false)
                                 } label: {
                                     Label("左に回転", systemImage: "rotate.left")
@@ -331,6 +356,14 @@ struct StickerLibraryView: View {
             maskEditSaved = true
         } catch {
             showOverwriteError = true
+        }
+    }
+
+    private func saveSticker(_ sticker: Sticker) {
+        Task {
+            let success = await StickerShareService.saveToPhotos(sticker)
+            saveToPhotosSuccess = success
+            showSaveToPhotosResult = true
         }
     }
 
@@ -438,6 +471,8 @@ struct StickerPreviewOverlay: View {
     var onDelete: () -> Void = {}
     var onMaskEdit: () -> Void = {}
     var onRotate: (Bool) -> Void = { _ in }
+    var onShare: () -> Void = {}
+    var onSaveToPhotos: () -> Void = {}
 
     @State private var previewImage: UIImage?
 
@@ -509,6 +544,35 @@ struct StickerPreviewOverlay: View {
                     }
                     .accessibilityLabel("右に90度回転")
                     .accessibilityHint("シールを時計回りに90度回転します")
+                }
+
+                // 共有・保存ボタン
+                HStack(spacing: 12) {
+                    Button {
+                        onShare()
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.white)
+                            .frame(width: 44, height: 44)
+                            .background(.white.opacity(0.15))
+                            .clipShape(Circle())
+                    }
+                    .accessibilityLabel("シールを共有")
+                    .accessibilityHint("シール画像をAirDrop・SNS等で共有します")
+
+                    Button {
+                        onSaveToPhotos()
+                    } label: {
+                        Image(systemName: "square.and.arrow.down")
+                            .font(.system(size: 20))
+                            .foregroundStyle(.white)
+                            .frame(width: 44, height: 44)
+                            .background(.white.opacity(0.15))
+                            .clipShape(Circle())
+                    }
+                    .accessibilityLabel("写真に保存")
+                    .accessibilityHint("シール画像をフォトライブラリに保存します")
                 }
 
                 // アクションボタン

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -518,18 +518,23 @@ struct StickerPreviewOverlay: View {
                     .foregroundStyle(.white.opacity(0.6))
 
                 Spacer(minLength: 0)
+
+                // 統合アクションバー（タブバーとホームインジケーター分の余白を確保）
+                stickerActionBar
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, actionBarBottomPadding)
             }
             .padding(.top, 60)
-            .padding(.bottom, 16)
-        }
-        // タブバーの上にアクションバーを配置（safeAreaInsetでセーフエリアを考慮）
-        .safeAreaInset(edge: .bottom, spacing: 0) {
-            stickerActionBar
-                .padding(.horizontal, 20)
-                .padding(.top, 12)
-                .padding(.bottom, 12)
         }
         .transition(.opacity)
+    }
+
+    /// タブバー（49pt）＋ホームインジケーター領域を考慮したアクションバーの底部余白
+    private var actionBarBottomPadding: CGFloat {
+        let homeIndicatorBottom = UIApplication.shared.connectedScenes
+            .compactMap { $0 as? UIWindowScene }
+            .first?.keyWindow?.safeAreaInsets.bottom ?? 34
+        return homeIndicatorBottom + 49 + 16  // ホームインジケーター + タブバー + 余白
     }
 
     // MARK: - 統合アクションバー

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -77,7 +77,7 @@ struct StickerLibraryView: View {
                 Text("シール画像の読み込みに失敗しました。画像が破損している可能性があります。")
             }
             .alert(
-                saveToPhotosSuccess ? "写真を保存しました" : "保存に失敗しました",
+                saveToPhotosSuccess ? LocalizedStringKey("写真を保存しました") : LocalizedStringKey("保存に失敗しました"),
                 isPresented: $showSaveToPhotosResult
             ) {
                 Button("OK", role: .cancel) {}

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -517,99 +517,119 @@ struct StickerPreviewOverlay: View {
                     .font(.system(size: 13, design: .rounded))
                     .foregroundStyle(.white.opacity(0.6))
 
-                // 回転ボタン
-                HStack(spacing: 12) {
-                    Button {
-                        onRotate(false)
-                    } label: {
-                        Image(systemName: "rotate.left")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.white)
-                            .frame(width: 44, height: 44)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("左に90度回転")
-                    .accessibilityHint("シールを反時計回りに90度回転します")
-
-                    Button {
-                        onRotate(true)
-                    } label: {
-                        Image(systemName: "rotate.right")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.white)
-                            .frame(width: 44, height: 44)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("右に90度回転")
-                    .accessibilityHint("シールを時計回りに90度回転します")
-                }
-
-                // 共有・保存ボタン
-                HStack(spacing: 12) {
-                    Button {
-                        onShare()
-                    } label: {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.white)
-                            .frame(width: 44, height: 44)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("シールを共有")
-                    .accessibilityHint("シール画像をAirDrop・SNS等で共有します")
-
-                    Button {
-                        onSaveToPhotos()
-                    } label: {
-                        Image(systemName: "square.and.arrow.down")
-                            .font(.system(size: 20))
-                            .foregroundStyle(.white)
-                            .frame(width: 44, height: 44)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Circle())
-                    }
-                    .accessibilityLabel("写真に保存")
-                    .accessibilityHint("シール画像をフォトライブラリに保存します")
-                }
-
-                // アクションボタン
-                HStack(spacing: 16) {
-                    Button {
-                        onDelete()
-                    } label: {
-                        Label("削除", systemImage: "trash")
-                            .font(.system(size: 14, weight: .medium, design: .rounded))
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 12)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Capsule())
-                    }
-                    .accessibilityLabel("シールを削除")
-
-                    Button {
-                        onMaskEdit()
-                    } label: {
-                        Label("再編集", systemImage: "eraser.line.dashed")
-                            .font(.system(size: 14, weight: .medium, design: .rounded))
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 12)
-                            .background(.white.opacity(0.15))
-                            .clipShape(Capsule())
-                    }
-                    .accessibilityLabel("マスクを再編集")
-                }
-                .padding(.top, 4)
-
                 Spacer(minLength: 0)
+
+                // 統合アクションバー
+                stickerActionBar
+                    .padding(.horizontal, 20)
+                    .padding(.bottom, 40)
             }
-            .padding(.vertical, 60)
+            .padding(.top, 60)
         }
         .transition(.opacity)
+    }
+
+    // MARK: - 統合アクションバー
+
+    private var stickerActionBar: some View {
+        HStack(spacing: 0) {
+            // グループ1: 回転
+            HStack(spacing: 0) {
+                overlayActionButton(
+                    icon: "rotate.left",
+                    label: String(localized: "左回転"),
+                    accessLabel: "左に90度回転",
+                    accessHint: "シールを反時計回りに90度回転します"
+                ) { onRotate(false) }
+
+                overlayActionButton(
+                    icon: "rotate.right",
+                    label: String(localized: "右回転"),
+                    accessLabel: "右に90度回転",
+                    accessHint: "シールを時計回りに90度回転します"
+                ) { onRotate(true) }
+            }
+            .frame(maxWidth: .infinity)
+
+            actionBarDivider
+
+            // グループ2: 出力
+            HStack(spacing: 0) {
+                overlayActionButton(
+                    icon: "square.and.arrow.up",
+                    label: String(localized: "共有"),
+                    accessLabel: "シールを共有",
+                    accessHint: "シール画像をAirDrop・SNS等で共有します"
+                ) { onShare() }
+
+                overlayActionButton(
+                    icon: "square.and.arrow.down",
+                    label: String(localized: "写真に保存"),
+                    accessLabel: "写真に保存",
+                    accessHint: "シール画像をフォトライブラリに保存します"
+                ) { onSaveToPhotos() }
+            }
+            .frame(maxWidth: .infinity)
+
+            actionBarDivider
+
+            // グループ3: 編集・削除
+            HStack(spacing: 0) {
+                overlayActionButton(
+                    icon: "eraser.line.dashed",
+                    label: String(localized: "再編集"),
+                    accessLabel: "マスクを再編集"
+                ) { onMaskEdit() }
+
+                overlayActionButton(
+                    icon: "trash",
+                    label: String(localized: "削除"),
+                    accessLabel: "シールを削除",
+                    tint: Color(red: 1.0, green: 0.35, blue: 0.35)
+                ) { onDelete() }
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .padding(.vertical, 12)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 22, style: .continuous)
+                .strokeBorder(.white.opacity(0.12), lineWidth: 1)
+        }
+    }
+
+    private var actionBarDivider: some View {
+        Rectangle()
+            .fill(.white.opacity(0.18))
+            .frame(width: 1, height: 36)
+    }
+
+    @ViewBuilder
+    private func overlayActionButton(
+        icon: String,
+        label: String,
+        accessLabel: String,
+        accessHint: String = "",
+        tint: Color = .white,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            VStack(spacing: 5) {
+                Image(systemName: icon)
+                    .font(.system(size: 17, weight: .regular))
+                    .foregroundStyle(tint)
+                Text(label)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .foregroundStyle(tint.opacity(0.75))
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessLabel)
+        .accessibilityHint(accessHint)
     }
 }
 

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -518,13 +518,16 @@ struct StickerPreviewOverlay: View {
                     .foregroundStyle(.white.opacity(0.6))
 
                 Spacer(minLength: 0)
-
-                // 統合アクションバー
-                stickerActionBar
-                    .padding(.horizontal, 20)
-                    .padding(.bottom, 40)
             }
             .padding(.top, 60)
+            .padding(.bottom, 16)
+        }
+        // タブバーの上にアクションバーを配置（safeAreaInsetでセーフエリアを考慮）
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            stickerActionBar
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 12)
         }
         .transition(.opacity)
     }

--- a/StickerBoardTests/StickerShareServiceTests.swift
+++ b/StickerBoardTests/StickerShareServiceTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+
+/// StickerShareService のテスト
+/// Issue #202: シール単体の画像ダウンロード・共有機能
+///
+/// 注意: このテストはソースコードを文字列として読み込み、パターンで構造を検証します。
+/// 対象ソースの構造が変更された場合はテストのパターンを実態に合わせて更新してください。
+struct StickerShareServiceTests {
+
+    // MARK: - ヘルパー
+
+    private var projectRootURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // StickerBoardTests/
+            .deletingLastPathComponent()   // project root
+    }
+
+    private func readFile(_ relativePath: String) throws -> String {
+        let url = projectRootURL.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private var shareServiceContent: String {
+        get throws { try readFile("StickerBoard/Services/StickerShareService.swift") }
+    }
+
+    private var libraryViewContent: String {
+        get throws { try readFile("StickerBoard/Views/Library/StickerLibraryView.swift") }
+    }
+
+    // MARK: - StickerShareService の構造
+
+    @Test func StickerShareServiceが存在する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("enum StickerShareService"),
+            "StickerShareService が定義されていません"
+        )
+    }
+
+    @Test func StickerShareService_MainActorで動作する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("@MainActor"),
+            "StickerShareService に @MainActor がありません"
+        )
+    }
+
+    @Test func share関数が存在する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("static func share("),
+            "share() 関数が定義されていません"
+        )
+    }
+
+    @Test func saveToPhotos関数が存在する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("static func saveToPhotos("),
+            "saveToPhotos() 関数が定義されていません"
+        )
+    }
+
+    @Test func saveToPhotos_asyncで実装されている() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("func saveToPhotos(") && content.contains("async"),
+            "saveToPhotos() が async になっていません"
+        )
+    }
+
+    @Test func saveToPhotos_PHPhotoLibraryを使用する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("PHPhotoLibrary"),
+            "saveToPhotos() が PHPhotoLibrary を使用していません"
+        )
+    }
+
+    @Test func saveToPhotos_権限チェックを行う() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("requestAuthorization"),
+            "saveToPhotos() が requestAuthorization による権限チェックをしていません"
+        )
+    }
+
+    @Test func presentShareSheet_UIActivityViewControllerを使用する() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("UIActivityViewController"),
+            "share() が UIActivityViewController を使用していません"
+        )
+    }
+
+    @Test func share_ImageStorageから画像を読み込む() throws {
+        let content = try shareServiceContent
+        #expect(
+            content.contains("ImageStorage"),
+            "share() が ImageStorage を使用していません"
+        )
+    }
+
+    // MARK: - StickerLibraryView の修正
+
+    @Test func ライブラリのコンテキストメニューに共有ボタンがある() throws {
+        let content = try libraryViewContent
+        #expect(
+            content.contains("StickerShareService.share"),
+            "StickerLibraryView のコンテキストメニューに共有ボタンがありません"
+        )
+    }
+
+    @Test func ライブラリのコンテキストメニューに保存ボタンがある() throws {
+        let content = try libraryViewContent
+        #expect(
+            content.contains("StickerShareService.saveToPhotos") ||
+            content.contains("saveToPhotos"),
+            "StickerLibraryView のコンテキストメニューに写真保存ボタンがありません"
+        )
+    }
+
+    @Test func プレビューオーバーレイにonShareコールバックがある() throws {
+        let content = try libraryViewContent
+        #expect(
+            content.contains("onShare"),
+            "StickerPreviewOverlay に onShare コールバックがありません"
+        )
+    }
+
+    @Test func プレビューオーバーレイにonSaveToPhotosコールバックがある() throws {
+        let content = try libraryViewContent
+        #expect(
+            content.contains("onSaveToPhotos"),
+            "StickerPreviewOverlay に onSaveToPhotos コールバックがありません"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- シールライブラリで個別シールの共有（AirDrop・SNS等）と写真保存が可能になりました
- `StickerShareService`（新規）: `UIActivityViewController` による共有・`PHPhotoLibrary` への写真保存
- `StickerLibraryView`: コンテキストメニューに「共有」「写真に保存」を追加
- `StickerPreviewOverlay`: 共有・保存アイコンボタンを追加

## Changes

- **新規** `StickerBoard/Services/StickerShareService.swift` — `@MainActor enum` で共有・保存ロジックを提供
- **修正** `StickerBoard/Views/Library/StickerLibraryView.swift` — コンテキストメニュー・プレビューオーバーレイに共有/保存UI追加
- **修正** `StickerBoard/Localizable.xcstrings` — 新規文字列の ja/en 翻訳を追加
- **新規** `StickerBoardTests/StickerShareServiceTests.swift` — Swift Testing によるユニットテスト

## Test plan

- [x] シールライブラリでシールを長押し → コンテキストメニューに「共有」「写真に保存」が表示される
- [x] 「共有」タップ → UIActivityViewController が表示され、AirDrop・保存・SNS等から選べる
- [ ] 「写真に保存」タップ → フォトライブラリ権限ダイアログが表示（初回のみ）→ 保存完了 or 失敗のアラートが表示される
- [x] シールをタップしてプレビュー表示 → 共有アイコン（↑）と保存アイコン（↓）ボタンが表示される
- [x] 英語環境で動作確認（Application Language を English に変更）

close #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)