### PR TITLE
perf: 背景除去のVision処理を統合し処理時間を短縮 + ローディングUIをオーバーレイ方式に改善

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ open StickerBoard.xcodeproj
 - StickerPlacement に imageFileName を直接保持する設計（SwiftDataのID問題回避のため）
 - Board の backgroundPatternData も placements と同様に Codable struct を JSON シリアライズして Data? に格納する設計
 - BackgroundRemover は入力画像の EXIF 向きを正規化し、長辺2048pxにリサイズする（cgImage とマスクの整合性確保 + メモリ最適化）
+- BackgroundRemover.processForCapture(from:) はキャプチャフロー専用の統合API。Vision を1回だけ呼び出し、被写体数に応じて `.singleSticker(BackgroundRemovalResult)` または `.multipleStickers([UIImage])` を返す `CaptureProcessingResult` enum に分岐する。StickerCaptureView.processImage() から呼び出す（旧 extractIndividualStickers + removeBackgroundWithMask の二段階呼び出しを廃止）
 - BackgroundRemover.removeBackgroundAtPoint(from:normalizedPoint:) は、VNInstanceMaskObservation の instanceMask ピクセルバッファからタップ位置のインスタンスIDを特定し、その被写体のみを切り抜く。StickerCaptureView で写真プレビューの長押しジェスチャーから呼び出される
 - フィルター（キラキラ・レトロ・パステル・ネオン・ぷっくり・ワッペン）は StickerPlacement の filterType に保存し、ボード配置単位で適用する設計（シール自体ではなく配置ごとにフィルターが異なる）
 - StickerFilterService は CIFilter ベースでオンザフライ処理。BoardEditorView ではフィルター適用画像をキャッシュして body 再評価時の再計算を回避

--- a/StickerBoard/Services/BackgroundRemover.swift
+++ b/StickerBoard/Services/BackgroundRemover.swift
@@ -167,8 +167,8 @@ struct BackgroundRemover {
         }
         let maskImage = UIImage(cgImage: maskCGImage)
 
-        // 合成画像を生成
-        let processedImage = try applyMask(observation, instances: observation.allInstances, to: cgImage, handler: handler)
+        // 合成画像を生成（生成済みの maskPixelBuffer を再利用して二重計算を回避）
+        let processedImage = try applyMask(maskPixelBuffer: maskPixelBuffer, to: cgImage)
 
         return BackgroundRemovalResult(processedImage: processedImage, maskImage: maskImage, originalImage: image)
     }

--- a/StickerBoard/Services/BackgroundRemover.swift
+++ b/StickerBoard/Services/BackgroundRemover.swift
@@ -199,9 +199,18 @@ struct BackgroundRemover {
             return [single]
         }
 
+        return try extractInstanceImages(from: observation, handler: handler, instances: allInstances)
+    }
+
+    /// 各インスタンスを個別に切り抜いて UIImage 配列として返す共通ヘルパー
+    private static func extractInstanceImages(
+        from observation: VNInstanceMaskObservation,
+        handler: VNImageRequestHandler,
+        instances: IndexSet
+    ) throws -> [UIImage] {
         var results: [UIImage] = []
-        for instanceId in allInstances {
-            let image: UIImage? = try autoreleasepool {
+        for instanceId in instances {
+            let sticker: UIImage? = try autoreleasepool {
                 let singleSet = IndexSet(integer: instanceId)
                 let maskedBuffer = try observation.generateMaskedImage(
                     ofInstances: singleSet,
@@ -214,7 +223,7 @@ struct BackgroundRemover {
                 }
                 return UIImage(cgImage: outputCGImage)
             }
-            if let image { results.append(image) }
+            if let sticker { results.append(sticker) }
         }
 
         if results.isEmpty {
@@ -237,28 +246,7 @@ struct BackgroundRemover {
         let allInstances = observation.allInstances
 
         if allInstances.count > 1 {
-            // 複数被写体: 個別に切り抜き
-            var results: [UIImage] = []
-            for instanceId in allInstances {
-                let sticker: UIImage? = try autoreleasepool {
-                    let singleSet = IndexSet(integer: instanceId)
-                    let maskedBuffer = try observation.generateMaskedImage(
-                        ofInstances: singleSet,
-                        from: handler,
-                        croppedToInstancesExtent: true
-                    )
-                    let ciImage = CIImage(cvPixelBuffer: maskedBuffer)
-                    guard let outputCGImage = ciContext.createCGImage(ciImage, from: ciImage.extent) else {
-                        return nil
-                    }
-                    return UIImage(cgImage: outputCGImage)
-                }
-                if let sticker { results.append(sticker) }
-            }
-
-            if results.isEmpty {
-                throw BackgroundRemoverError.noResult
-            }
+            let results = try extractInstanceImages(from: observation, handler: handler, instances: allInstances)
             return .multipleStickers(results)
         } else {
             // 単一被写体: マスク付きで返す（手動調整対応）
@@ -269,7 +257,7 @@ struct BackgroundRemover {
             }
             let maskImage = UIImage(cgImage: maskCGImage)
 
-            let processedImage = try applyMask(observation, instances: allInstances, to: cgImage, handler: handler)
+            let processedImage = try applyMask(maskPixelBuffer: maskPixelBuffer, to: cgImage)
 
             return .singleSticker(BackgroundRemovalResult(processedImage: processedImage, maskImage: maskImage, originalImage: image))
         }

--- a/StickerBoard/Services/BackgroundRemover.swift
+++ b/StickerBoard/Services/BackgroundRemover.swift
@@ -3,6 +3,12 @@ import Vision
 import CoreImage
 import CoreImage.CIFilterBuiltins
 
+/// キャプチャフローの処理結果（単一 or 複数シール）
+enum CaptureProcessingResult {
+    case singleSticker(BackgroundRemovalResult)
+    case multipleStickers([UIImage])
+}
+
 struct BackgroundRemover {
 
     private static let ciContext = SharedCIContext.shared
@@ -82,6 +88,17 @@ struct BackgroundRemover {
         return [normalized]
         #else
         return try extractIndividualStickersReal(from: normalized)
+        #endif
+    }
+
+    /// キャプチャフロー用の統合処理（Vision を1回だけ呼び出して分岐する）
+    static func processForCapture(from image: UIImage) async throws -> CaptureProcessingResult {
+        let normalized = normalizeOrientation(image)
+        #if targetEnvironment(simulator)
+        let whiteMask = createWhiteMask(size: normalized.size)
+        return .singleSticker(BackgroundRemovalResult(processedImage: normalized, maskImage: whiteMask, originalImage: normalized))
+        #else
+        return try processForCaptureReal(from: normalized)
         #endif
     }
 
@@ -204,6 +221,58 @@ struct BackgroundRemover {
             throw BackgroundRemoverError.noResult
         }
         return results
+    }
+
+    private static func processForCaptureReal(from image: UIImage) throws -> CaptureProcessingResult {
+        guard let cgImage = image.cgImage else {
+            throw BackgroundRemoverError.invalidImage
+        }
+
+        guard let (observation, handler) = try performInstanceMask(on: cgImage) else {
+            // 被写体が検出されなかった場合、白マスクで単一シールとして返す
+            let whiteMask = createWhiteMask(size: image.size)
+            return .singleSticker(BackgroundRemovalResult(processedImage: image, maskImage: whiteMask, originalImage: image))
+        }
+
+        let allInstances = observation.allInstances
+
+        if allInstances.count > 1 {
+            // 複数被写体: 個別に切り抜き
+            var results: [UIImage] = []
+            for instanceId in allInstances {
+                let sticker: UIImage? = try autoreleasepool {
+                    let singleSet = IndexSet(integer: instanceId)
+                    let maskedBuffer = try observation.generateMaskedImage(
+                        ofInstances: singleSet,
+                        from: handler,
+                        croppedToInstancesExtent: true
+                    )
+                    let ciImage = CIImage(cvPixelBuffer: maskedBuffer)
+                    guard let outputCGImage = ciContext.createCGImage(ciImage, from: ciImage.extent) else {
+                        return nil
+                    }
+                    return UIImage(cgImage: outputCGImage)
+                }
+                if let sticker { results.append(sticker) }
+            }
+
+            if results.isEmpty {
+                throw BackgroundRemoverError.noResult
+            }
+            return .multipleStickers(results)
+        } else {
+            // 単一被写体: マスク付きで返す（手動調整対応）
+            let maskPixelBuffer = try observation.generateScaledMaskForImage(forInstances: allInstances, from: handler)
+            let ciMask = CIImage(cvPixelBuffer: maskPixelBuffer)
+            guard let maskCGImage = ciContext.createCGImage(ciMask, from: ciMask.extent) else {
+                throw BackgroundRemoverError.renderFailed
+            }
+            let maskImage = UIImage(cgImage: maskCGImage)
+
+            let processedImage = try applyMask(observation, instances: allInstances, to: cgImage, handler: handler)
+
+            return .singleSticker(BackgroundRemovalResult(processedImage: processedImage, maskImage: maskImage, originalImage: image))
+        }
     }
 
     private static func createWhiteMask(size: CGSize) -> UIImage {

--- a/StickerBoard/Services/BackgroundRemover.swift
+++ b/StickerBoard/Services/BackgroundRemover.swift
@@ -202,13 +202,15 @@ struct BackgroundRemover {
         return try extractInstanceImages(from: observation, handler: handler, instances: allInstances)
     }
 
-    /// 各インスタンスを個別に切り抜いて UIImage 配列として返す共通ヘルパー
+    /// 指定されたインスタンスを1件ずつ切り抜いて UIImage 配列を返す。
+    /// instances は空でないことを前提とする。全件レンダリング失敗した場合は noResult をスロー。
     private static func extractInstanceImages(
         from observation: VNInstanceMaskObservation,
         handler: VNImageRequestHandler,
         instances: IndexSet
     ) throws -> [UIImage] {
         var results: [UIImage] = []
+        var failedCount = 0
         for instanceId in instances {
             let sticker: UIImage? = try autoreleasepool {
                 let singleSet = IndexSet(integer: instanceId)
@@ -223,7 +225,15 @@ struct BackgroundRemover {
                 }
                 return UIImage(cgImage: outputCGImage)
             }
-            if let sticker { results.append(sticker) }
+            if let sticker {
+                results.append(sticker)
+            } else {
+                failedCount += 1
+            }
+        }
+
+        if failedCount > 0 {
+            print("[BackgroundRemover] extractInstanceImages: \(failedCount)件のインスタンスのレンダリングに失敗しました（成功: \(results.count)件）")
         }
 
         if results.isEmpty {
@@ -244,6 +254,12 @@ struct BackgroundRemover {
         }
 
         let allInstances = observation.allInstances
+
+        guard !allInstances.isEmpty else {
+            // Vision が observation を返したが被写体インスタンスがない場合は白マスクでフォールバック
+            let whiteMask = createWhiteMask(size: image.size)
+            return .singleSticker(BackgroundRemovalResult(processedImage: image, maskImage: whiteMask, originalImage: image))
+        }
 
         if allInstances.count > 1 {
             let results = try extractInstanceImages(from: observation, handler: handler, instances: allInstances)

--- a/StickerBoard/Views/Capture/StickerCaptureView.swift
+++ b/StickerBoard/Views/Capture/StickerCaptureView.swift
@@ -48,8 +48,6 @@ struct StickerCaptureView: View {
                     } else if originalImage != nil {
                         // 写真プレビュー（処理中はオーバーレイ表示）
                         pickerSection
-                    } else if isProcessing {
-                        processingSection
                     } else {
                         pickerSection
                     }
@@ -244,6 +242,7 @@ struct StickerCaptureView: View {
                                     }
                                 }
                                 .accessibilityElement(children: .combine)
+                                .accessibilityLabel("背景を除去しています。しばらくお待ちください")
                                 .onAppear {
                                     AccessibilityNotification.Announcement("背景を除去しています").post()
                                 }
@@ -612,9 +611,7 @@ struct StickerCaptureView: View {
                     errorMessage = error.localizedDescription
                 }
             }
-            if !Task.isCancelled {
-                withAnimation { isProcessing = false }
-            }
+            withAnimation { isProcessing = false }
         }
     }
 

--- a/StickerBoard/Views/Capture/StickerCaptureView.swift
+++ b/StickerBoard/Views/Capture/StickerCaptureView.swift
@@ -45,6 +45,9 @@ struct StickerCaptureView: View {
                     } else if let processedImage {
                         // 切り抜き結果（単一）
                         resultSection(processedImage)
+                    } else if originalImage != nil {
+                        // 写真プレビュー（処理中はオーバーレイ表示）
+                        pickerSection
                     } else if isProcessing {
                         processingSection
                     } else {
@@ -224,27 +227,52 @@ struct StickerCaptureView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 16))
                         .shadow(color: .black.opacity(0.1), radius: 8, y: 4)
                         .overlay {
-                            GeometryReader { geometry in
-                                Color.clear
-                                    .contentShape(Rectangle())
-                                    .gesture(
-                                        LongPressGesture(minimumDuration: 0.5)
-                                            .sequenced(before: DragGesture(minimumDistance: 0))
-                                            .onChanged { value in
-                                                switch value {
-                                                case .second(true, let drag):
-                                                    if let drag, !isProcessing {
-                                                        pressLocation = drag.startLocation
-                                                        longPressImageViewSize = geometry.size
-                                                        let generator = UIImpactFeedbackGenerator(style: .medium)
-                                                        generator.impactOccurred()
-                                                        processImageAtPoint()
+                            if isProcessing {
+                                ZStack {
+                                    RoundedRectangle(cornerRadius: 16)
+                                        .fill(.black.opacity(0.5))
+                                    VStack(spacing: 12) {
+                                        ProgressView()
+                                            .controlSize(.large)
+                                            .tint(.white)
+                                        Text("背景を除去しています...")
+                                            .font(.system(size: 15, weight: .semibold, design: .rounded))
+                                            .foregroundStyle(.white)
+                                        Text("AIが被写体を検出しています")
+                                            .font(.system(size: 12, design: .rounded))
+                                            .foregroundStyle(.white.opacity(0.7))
+                                    }
+                                }
+                                .accessibilityElement(children: .combine)
+                                .onAppear {
+                                    AccessibilityNotification.Announcement("背景を除去しています").post()
+                                }
+                            }
+                        }
+                        .overlay {
+                            if !isProcessing {
+                                GeometryReader { geometry in
+                                    Color.clear
+                                        .contentShape(Rectangle())
+                                        .gesture(
+                                            LongPressGesture(minimumDuration: 0.5)
+                                                .sequenced(before: DragGesture(minimumDistance: 0))
+                                                .onChanged { value in
+                                                    switch value {
+                                                    case .second(true, let drag):
+                                                        if let drag {
+                                                            pressLocation = drag.startLocation
+                                                            longPressImageViewSize = geometry.size
+                                                            let generator = UIImpactFeedbackGenerator(style: .medium)
+                                                            generator.impactOccurred()
+                                                            processImageAtPoint()
+                                                        }
+                                                    default:
+                                                        break
                                                     }
-                                                default:
-                                                    break
                                                 }
-                                            }
-                                    )
+                                        )
+                                }
                             }
                         }
                         .accessibilityLabel("選択した写真のプレビュー")
@@ -264,12 +292,13 @@ struct StickerCaptureView: View {
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
-                        .foregroundStyle(AppTheme.secondary)
+                        .foregroundStyle(isProcessing ? AppTheme.secondary.opacity(0.4) : AppTheme.secondary)
                         .background {
                             RoundedRectangle(cornerRadius: 14)
-                                .strokeBorder(AppTheme.secondary, lineWidth: 2)
+                                .strokeBorder(isProcessing ? AppTheme.secondary.opacity(0.4) : AppTheme.secondary, lineWidth: 2)
                         }
                     }
+                    .disabled(isProcessing)
                     .accessibilityLabel("すべて自動で切り抜く")
                     .accessibilityHint("写真内のすべての被写体を自動的に検出して切り抜きます")
                 }
@@ -561,25 +590,20 @@ struct StickerCaptureView: View {
         processingTask?.cancel()
         processingTask = Task {
             do {
-                // まず複数オブジェクト検出を試みる
-                let results = try await BackgroundRemover.extractIndividualStickers(from: originalImage)
+                let result = try await BackgroundRemover.processForCapture(from: originalImage)
 
                 guard !Task.isCancelled else { return }
 
-                if results.count > 1 {
+                switch result {
+                case .singleSticker(let bgResult):
                     withAnimation(.spring(duration: 0.5)) {
-                        extractedStickers = results
+                        backgroundRemovalResult = bgResult
+                        processedImage = bgResult.processedImage
                         self.originalImage = nil
                     }
-                } else {
-                    // 単一シール: マスク付きで処理（手動調整を可能にする）
-                    let result = try await BackgroundRemover.removeBackgroundWithMask(from: originalImage)
-
-                    guard !Task.isCancelled else { return }
-
+                case .multipleStickers(let stickers):
                     withAnimation(.spring(duration: 0.5)) {
-                        backgroundRemovalResult = result
-                        processedImage = result.processedImage
+                        extractedStickers = stickers
                         self.originalImage = nil
                     }
                 }


### PR DESCRIPTION
単一被写体画像でVision の performInstanceMask() が2回呼ばれていた問題を修正。
processForCapture() メソッドで1回の呼び出しに統合し処理時間を大幅に短縮。

ローディング表示を画面全体の差し替えから写真プレビュー上のオーバーレイ方式に
変更し、処理中であることをユーザーに直感的に伝えるようにした。

https://claude.ai/code/session_01Y46w9peFAD7iQSbwvfNXuy