### PR TITLE
fix: ピンチジェスチャー繰り返しによるクラッシュを修正 (#221)

### DIFF
--- a/StickerBoard.xcodeproj/project.pbxproj
+++ b/StickerBoard.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		567094296030D6D397CCFDA2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F870EE68E060BE5480814A21 /* Assets.xcassets */; };
 		57ADA124B508F310C9786DDD /* SettingsAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA269B34011892E6EAED96D /* SettingsAccessibilityTests.swift */; };
 		5AAD2F7A210494638C8EEBB5 /* CaptureAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530CD661BF00498FE8299E3E /* CaptureAccessibilityTests.swift */; };
+		6067D39F10AE564CBDA09EA8 /* BoardEditorPinchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75326EBD9D2597D4ABB590F /* BoardEditorPinchPerformanceTests.swift */; };
 		62899C4D692BD195F7F0A16B /* OnboardingPageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6669D6CA5D4EAD5DB7BF3C /* OnboardingPageIndicator.swift */; };
 		65C2B4E7FEA4EACCD89B17F5 /* WidgetDataSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA9B705D7B3675A472439D3 /* WidgetDataSyncService.swift */; };
 		6E80A247DC5FCB47A37C937C /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2E37E2FABECAE9B23C7CF61 /* KeychainHelperTests.swift */; };
@@ -232,6 +233,7 @@
 		BFB6A08C090537657BB85CAD /* BoardEditorToolbarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorToolbarTests.swift; sourceTree = "<group>"; };
 		C1211D3F280555E23A6562B3 /* ImageCacheManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageCacheManager.swift; sourceTree = "<group>"; };
 		C592ED5BC9F9E05F81F080EB /* ReviewRequestManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReviewRequestManagerTests.swift; sourceTree = "<group>"; };
+		C75326EBD9D2597D4ABB590F /* BoardEditorPinchPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorPinchPerformanceTests.swift; sourceTree = "<group>"; };
 		C772005BADEC8B242A0A39E8 /* OnboardingAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingAccessibilityTests.swift; sourceTree = "<group>"; };
 		C94311FE1E30296BB608F927 /* SharedCIContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedCIContext.swift; sourceTree = "<group>"; };
 		CBF271962CA9EF750652A353 /* StickerItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerItemView.swift; sourceTree = "<group>"; };
@@ -507,6 +509,7 @@
 				453EB379EB98A3F0EDA2660F /* BoardAccessibilityTests.swift */,
 				4C642A18BD372D652AF5FF3B /* BoardDeleteConfirmationTests.swift */,
 				05D64C35BE0EE1118E31B7E3 /* BoardEditorBindingTests.swift */,
+				C75326EBD9D2597D4ABB590F /* BoardEditorPinchPerformanceTests.swift */,
 				BFB6A08C090537657BB85CAD /* BoardEditorToolbarTests.swift */,
 				5FC4DAF0371E295F74BAD946 /* BoardEditorUndoTests.swift */,
 				7D5AF5A572900934DD45A38A /* BoardShareServiceTests.swift */,
@@ -757,6 +760,7 @@
 				E4535CB2569518D2A9E42749 /* BoardAccessibilityTests.swift in Sources */,
 				39D882D756B491224A0C519C /* BoardDeleteConfirmationTests.swift in Sources */,
 				EF33BC7291CF1E7AC2831ED8 /* BoardEditorBindingTests.swift in Sources */,
+				6067D39F10AE564CBDA09EA8 /* BoardEditorPinchPerformanceTests.swift in Sources */,
 				B64557CBC40B089B6FDFB338 /* BoardEditorToolbarTests.swift in Sources */,
 				1E97A5A5CAE9D4FBC8421696 /* BoardEditorUndoTests.swift in Sources */,
 				D60EA71E7EF817ABF7C9D220 /* BoardShareServiceTests.swift in Sources */,

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -29,6 +29,7 @@ struct BoardEditorView: View {
     @State private var rebuildTask: Task<Void, Never>?
     @State private var updateTask: Task<Void, Never>?
     @State private var widgetSyncTask: Task<Void, Never>?
+    @State private var widgetSyncDebounceTask: Task<Void, Never>?
     @State private var hasPerformedInitialSync = false
     @State private var undoStack: [(placements: [StickerPlacement], backgroundConfig: BackgroundPatternConfig)] = []
 
@@ -218,7 +219,12 @@ struct BoardEditorView: View {
         .onDisappear {
             rebuildTask?.cancel()
             updateTask?.cancel()
-            saveBoard()
+            widgetSyncTask?.cancel()
+            widgetSyncDebounceTask?.cancel()
+            board.placements = placements
+            board.updatedAt = Date()
+            try? modelContext.save()
+            syncBoardToWidget()
             loadedImages = [:]
         }
         .onChange(of: canvasSize) { oldSize, newSize in
@@ -758,7 +764,21 @@ struct BoardEditorView: View {
         board.placements = placements
         board.updatedAt = Date()
         try? modelContext.save()
-        syncBoardToWidget()
+        debouncedSyncBoardToWidget()
+    }
+
+    /// ウィジェット同期をデバウンスして実行する。
+    /// 高頻度なジェスチャー操作（ピンチ拡大縮小の連続操作など）で saveBoard() が連続発火した場合に、
+    /// 重たい ImageRenderer 処理（3種類のウィジェットスナップショット生成）が並列で積み重なり、
+    /// メモリ圧迫→クラッシュを引き起こす問題を防ぐ。
+    /// 最後の呼び出しから 500ms 後に1回だけ syncBoardToWidget() を実行する。
+    private func debouncedSyncBoardToWidget() {
+        widgetSyncDebounceTask?.cancel()
+        widgetSyncDebounceTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(500))
+            guard !Task.isCancelled else { return }
+            syncBoardToWidget()
+        }
     }
 
     private func syncBoardToWidget() {

--- a/StickerBoardTests/BoardEditorPinchPerformanceTests.swift
+++ b/StickerBoardTests/BoardEditorPinchPerformanceTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+
+/// ボード編集画面のピンチジェスチャーパフォーマンステスト
+/// Issue #221: ボード内でのシールの操作を拡大縮小を続けるとクラッシュする
+///
+/// ## 問題の背景
+/// 高速なピンチ操作を繰り返すと、onGestureEnded ごとに syncBoardToWidget() が発火し、
+/// 各呼び出しで3つのImageRenderer（medium/large/small）が生成される。
+/// ImageRendererは数MBのUIImageをメモリに確保するため、連続発火でメモリ圧迫→クラッシュ。
+///
+/// ## 修正方針
+/// syncBoardToWidget() の呼び出しをデバウンスし、
+/// 連続したジェスチャー操作では最後の操作から一定時間後のみ実行する。
+///
+/// 注意: このテストはソースコードを文字列として読み込み、パターンマッチで構造を検証します。
+/// BoardEditorView.swift のメソッド名・構造が変更された場合、
+/// テストのパターンマッチを実態に合わせて更新してください。
+struct BoardEditorPinchPerformanceTests {
+
+    // MARK: - ファイル読み込みヘルパー
+
+    private var projectRootURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func readFile(_ relativePath: String) throws -> String {
+        let url = projectRootURL.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private var editorContent: String {
+        get throws { try readFile("StickerBoard/Views/Board/BoardEditorView.swift") }
+    }
+
+    // MARK: - デバウンス機構
+
+    @Test func widgetSyncDebounceTask状態変数が定義されている() throws {
+        let content = try editorContent
+        #expect(content.contains("widgetSyncDebounceTask"),
+                "widgetSyncDebounceTask状態変数が定義されていません")
+    }
+
+    @Test func debouncedSyncBoardToWidget関数が定義されている() throws {
+        let content = try editorContent
+        #expect(content.contains("func debouncedSyncBoardToWidget()"),
+                "debouncedSyncBoardToWidget()関数が定義されていません")
+    }
+
+    @Test func debouncedSyncBoardToWidgetがTask_sleepでデバウンスしている() throws {
+        let content = try editorContent
+        let range = try #require(content.range(of: "func debouncedSyncBoardToWidget()"))
+        let funcBody = content[range.lowerBound...]
+        // 関数本体の閉じ括弧を探す
+        var braceCount = 0
+        var endIndex = funcBody.startIndex
+        var started = false
+        for idx in funcBody.indices {
+            if funcBody[idx] == "{" {
+                braceCount += 1
+                started = true
+            } else if funcBody[idx] == "}" {
+                braceCount -= 1
+            }
+            endIndex = idx
+            if started && braceCount == 0 { break }
+        }
+        let body = String(funcBody[funcBody.startIndex...endIndex])
+        #expect(body.contains("Task.sleep"),
+                "debouncedSyncBoardToWidget内でTask.sleepによるデバウンスが実装されていません")
+    }
+
+    @Test func saveBoardがdebouncedSyncBoardToWidgetを呼ぶ() throws {
+        let content = try editorContent
+        let range = try #require(content.range(of: "func saveBoard()"))
+        let saveBoardBody = content[range.lowerBound...]
+        // saveBoard関数の本体を抽出
+        var braceCount = 0
+        var endIndex = saveBoardBody.startIndex
+        var started = false
+        for idx in saveBoardBody.indices {
+            if saveBoardBody[idx] == "{" {
+                braceCount += 1
+                started = true
+            } else if saveBoardBody[idx] == "}" {
+                braceCount -= 1
+            }
+            endIndex = idx
+            if started && braceCount == 0 { break }
+        }
+        let body = String(saveBoardBody[saveBoardBody.startIndex...endIndex])
+        #expect(body.contains("debouncedSyncBoardToWidget()"),
+                "saveBoard内でdebouncedSyncBoardToWidget()を呼んでいません（直接syncBoardToWidget()を呼ぶとクラッシュの原因になります）")
+    }
+
+    // MARK: - onDisappear でのタスクキャンセル
+
+    @Test func onDisappearでwidgetSyncTaskがキャンセルされる() throws {
+        let content = try editorContent
+        let range = try #require(content.range(of: ".onDisappear"))
+        let onDisappearBody = content[range.lowerBound...]
+        var braceCount = 0
+        var endIndex = onDisappearBody.startIndex
+        var started = false
+        for idx in onDisappearBody.indices {
+            if onDisappearBody[idx] == "{" {
+                braceCount += 1
+                started = true
+            } else if onDisappearBody[idx] == "}" {
+                braceCount -= 1
+            }
+            endIndex = idx
+            if started && braceCount == 0 { break }
+        }
+        let body = String(onDisappearBody[onDisappearBody.startIndex...endIndex])
+        #expect(body.contains("widgetSyncTask?.cancel()"),
+                "onDisappear内でwidgetSyncTask?.cancel()が呼ばれていません（タスクリークの原因）")
+    }
+
+    @Test func onDisappearでwidgetSyncDebounceTaskがキャンセルされる() throws {
+        let content = try editorContent
+        let range = try #require(content.range(of: ".onDisappear"))
+        let onDisappearBody = content[range.lowerBound...]
+        var braceCount = 0
+        var endIndex = onDisappearBody.startIndex
+        var started = false
+        for idx in onDisappearBody.indices {
+            if onDisappearBody[idx] == "{" {
+                braceCount += 1
+                started = true
+            } else if onDisappearBody[idx] == "}" {
+                braceCount -= 1
+            }
+            endIndex = idx
+            if started && braceCount == 0 { break }
+        }
+        let body = String(onDisappearBody[onDisappearBody.startIndex...endIndex])
+        #expect(body.contains("widgetSyncDebounceTask?.cancel()"),
+                "onDisappear内でwidgetSyncDebounceTask?.cancel()が呼ばれていません")
+    }
+}


### PR DESCRIPTION
## Summary

- `saveBoard()` から呼ばれる `syncBoardToWidget()` に 500ms デバウンスを追加
- 高速なピンチ拡大縮小の繰り返しで、3つの `ImageRenderer`（medium/large/small ウィジェット用）が連続生成され OOM クラッシュする問題を解消
- `onDisappear` で `widgetSyncTask` のキャンセル漏れを修正し、タスクリークを防止

## 問題の原因

```
ユーザーが高速ピンチ繰り返し
  ↓ 各ジェスチャー終了時
onGestureEnded → saveBoard() → syncBoardToWidget()
  ↓ 1回の呼び出しで
ImageRenderer × 3（medium/large/small、各2x scale）
= 数MBのUIImage が並列で積み重なる
  ↓
メモリ圧迫 → クラッシュ
```

## 修正内容

### `debouncedSyncBoardToWidget()`（新規）
```swift
private func debouncedSyncBoardToWidget() {
    widgetSyncDebounceTask?.cancel()
    widgetSyncDebounceTask = Task { @MainActor in
        try? await Task.sleep(for: .milliseconds(500))
        guard !Task.isCancelled else { return }
        syncBoardToWidget()
    }
}
```
連続した操作では最後の操作から 500ms 後に1回だけ `syncBoardToWidget()` を実行。

### `onDisappear` のタスクキャンセル修正
```swift
widgetSyncTask?.cancel()         // 追加
widgetSyncDebounceTask?.cancel() // 追加
```
画面を離れる際に進行中のタスクを確実にキャンセル。

## Test plan

- [ ] ボード編集画面を開く
- [ ] シールを1枚以上配置する
- [ ] 同じシールをピンチで拡大→縮小→拡大→縮小を5〜10回素早く繰り返す
- [ ] クラッシュしないことを確認
- [ ] 操作後にウィジェットが（少し遅れて）更新されることを確認
- [ ] ボード編集を終了してウィジェットのスナップショットが正しいことを確認
- [ ] `BoardEditorPinchPerformanceTests` 全6テストがパスすること

close #221

🤖 Generated with [Claude Code](https://claude.com/claude-code)