### PR TITLE
feat: ボード編集画面に自動保存機能を追加 (#222)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,6 +88,7 @@ open StickerBoard.xcodeproj
 - サムネイル表示（StickerThumbnailView, QuickPickThumbnail, BoardStickerPreviewView）は ImageStorage.loadThumbnail() 経由で縮小画像を使用
 - 枠線（ボーダー）は StickerPlacement の borderWidthType / borderColorHex に保存し、フィルターと同様に配置単位で管理する設計
 - シールロックは StickerPlacement の isLocked: Bool = false に保存（旧データとの後方互換性: decodeIfPresent でデフォルト false）。ロック中はドラッグ・ピンチ・回転ジェスチャーおよび効果・枠線・前面・背面・削除ボタンを無効化。VoiceOver はロック/解除アクション + UIAccessibility.post アナウンス対応
+- 自動保存（BoardEditorView）: 2層構造でデータを保護。層1: `@Environment(\.scenePhase)` の `.background`/`.inactive` 移行時に `saveBoard()` を即時呼び出し（`.background` 時は `syncBoardToWidget()` も直接呼び出してデバウンス遅延前のサスペンドに備える）。層2: `onChange(of: placements)` / `onChange(of: backgroundConfig)` で 800ms デバウンスの `scheduleAutoSave()` をトリガー（ジェスチャー中クラッシュ対策）。`autoSaveTask` は `onDisappear` でキャンセル。既存の明示的 `saveBoard()` 呼び出しはすべてそのまま残す設計（即時保存の保証・Widget同期タイミングの維持）
 - Undo機能: BoardEditorView の `undoStack: [(placements: [StickerPlacement], backgroundConfig: BackgroundPatternConfig)]`（最大20ステップ）で操作前スナップショットを管理。`saveUndoSnapshot()` は重複チェック付き（同一状態はスキップ）。`undoLastAction()` はスタックをpopして状態を復元後 `rebuildFilterCache()` → `saveBoard()` を呼ぶ（削除undoで画像が消えないよう必須）。StickerItemView の `onGestureStarted` コールバックでジェスチャー開始時にスナップショットを保存。VoiceOverアクセシビリティアクション（移動/リサイズ/回転/ロック）も `onGestureStarted` 経由でundo対応済み。`StickerPlacement` は `Equatable` に準拠（重複チェック用）
 - StickerBorderService は CIMorphologyMaximum でアルファマスクを膨張させて輪郭に沿った枠線を描画。フィルター適用後の画像に枠線を重ねる（描画順序: フィルター → 枠線）
 - ImageCacheManager の processed() メソッドがフィルター＋枠線の統合キャッシュを管理。キーは「fileName_filterType_borderWidth_borderColorHex」形式

--- a/StickerBoard.xcodeproj/project.pbxproj
+++ b/StickerBoard.xcodeproj/project.pbxproj
@@ -44,6 +44,7 @@
 		567094296030D6D397CCFDA2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F870EE68E060BE5480814A21 /* Assets.xcassets */; };
 		57ADA124B508F310C9786DDD /* SettingsAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA269B34011892E6EAED96D /* SettingsAccessibilityTests.swift */; };
 		5AAD2F7A210494638C8EEBB5 /* CaptureAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 530CD661BF00498FE8299E3E /* CaptureAccessibilityTests.swift */; };
+		5B8080F39AD1A32DC7ED0038 /* BoardEditorAutoSaveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1291650F18A23BA888E48341 /* BoardEditorAutoSaveTests.swift */; };
 		6067D39F10AE564CBDA09EA8 /* BoardEditorPinchPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C75326EBD9D2597D4ABB590F /* BoardEditorPinchPerformanceTests.swift */; };
 		62899C4D692BD195F7F0A16B /* OnboardingPageIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A6669D6CA5D4EAD5DB7BF3C /* OnboardingPageIndicator.swift */; };
 		65C2B4E7FEA4EACCD89B17F5 /* WidgetDataSyncService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AA9B705D7B3675A472439D3 /* WidgetDataSyncService.swift */; };
@@ -155,6 +156,7 @@
 		0D6802D6762B69A0CA2A7336 /* MaskCompositor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskCompositor.swift; sourceTree = "<group>"; };
 		10C7D9DE578356B33FB1A231 /* BoardShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardShareService.swift; sourceTree = "<group>"; };
 		11C89501ABCC774418176436 /* WidgetModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetModelsTests.swift; sourceTree = "<group>"; };
+		1291650F18A23BA888E48341 /* BoardEditorAutoSaveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorAutoSaveTests.swift; sourceTree = "<group>"; };
 		184AC63B41CB824E00123DE8 /* DebugPrintRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugPrintRemovalTests.swift; sourceTree = "<group>"; };
 		19E5D6F908EE947CC125BAC4 /* StickerBorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerBorder.swift; sourceTree = "<group>"; };
 		1A6669D6CA5D4EAD5DB7BF3C /* OnboardingPageIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingPageIndicator.swift; sourceTree = "<group>"; };
@@ -508,6 +510,7 @@
 				FB6EDAB9B790B0F91276B35D /* BackgroundRemoverTests.swift */,
 				453EB379EB98A3F0EDA2660F /* BoardAccessibilityTests.swift */,
 				4C642A18BD372D652AF5FF3B /* BoardDeleteConfirmationTests.swift */,
+				1291650F18A23BA888E48341 /* BoardEditorAutoSaveTests.swift */,
 				05D64C35BE0EE1118E31B7E3 /* BoardEditorBindingTests.swift */,
 				C75326EBD9D2597D4ABB590F /* BoardEditorPinchPerformanceTests.swift */,
 				BFB6A08C090537657BB85CAD /* BoardEditorToolbarTests.swift */,
@@ -759,6 +762,7 @@
 				ED41EDEDCF9EB89E47B5B802 /* BackgroundRemoverTests.swift in Sources */,
 				E4535CB2569518D2A9E42749 /* BoardAccessibilityTests.swift in Sources */,
 				39D882D756B491224A0C519C /* BoardDeleteConfirmationTests.swift in Sources */,
+				5B8080F39AD1A32DC7ED0038 /* BoardEditorAutoSaveTests.swift in Sources */,
 				EF33BC7291CF1E7AC2831ED8 /* BoardEditorBindingTests.swift in Sources */,
 				6067D39F10AE564CBDA09EA8 /* BoardEditorPinchPerformanceTests.swift in Sources */,
 				B64557CBC40B089B6FDFB338 /* BoardEditorToolbarTests.swift in Sources */,

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -231,7 +231,9 @@ struct BoardEditorView: View {
             loadedImages = [:]
         }
         .onChange(of: scenePhase) { _, newPhase in
-            if newPhase == .background {
+            // .inactive も対象にすることで、着信やコントロールセンター表示など
+            // .background に遷移しないケースでもデータを保護する
+            if newPhase == .background || newPhase == .inactive {
                 saveBoard()
             }
         }
@@ -783,6 +785,8 @@ struct BoardEditorView: View {
 
     /// 800ms デバウンスで saveBoard() を呼び出す。
     /// ジェスチャー実行中のクラッシュや onChange の連続発火に対する安全網として機能する。
+    /// 各操作の明示的な saveBoard() と二重保存になるケースがあるが、
+    /// これは意図的な設計（即時保存の保証 + ウィジェット同期タイミングの維持）。
     private func scheduleAutoSave() {
         autoSaveTask?.cancel()
         autoSaveTask = Task { @MainActor in

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -9,6 +9,7 @@ struct BoardEditorView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.displayScale) private var displayScale
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
 
     @State private var placements: [StickerPlacement] = []
     @State private var selectedPlacementId: UUID?
@@ -32,6 +33,7 @@ struct BoardEditorView: View {
     @State private var widgetSyncDebounceTask: Task<Void, Never>?
     @State private var hasPerformedInitialSync = false
     @State private var undoStack: [(placements: [StickerPlacement], backgroundConfig: BackgroundPatternConfig)] = []
+    @State private var autoSaveTask: Task<Void, Never>?
 
     private let undoStackLimit = 20
 
@@ -217,6 +219,7 @@ struct BoardEditorView: View {
             rebuildFilterCache()
         }
         .onDisappear {
+            autoSaveTask?.cancel()
             rebuildTask?.cancel()
             updateTask?.cancel()
             widgetSyncTask?.cancel()
@@ -226,6 +229,17 @@ struct BoardEditorView: View {
             try? modelContext.save()
             syncBoardToWidget()
             loadedImages = [:]
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background {
+                saveBoard()
+            }
+        }
+        .onChange(of: placements) { _, _ in
+            scheduleAutoSave()
+        }
+        .onChange(of: backgroundConfig) { _, _ in
+            scheduleAutoSave()
         }
         .onChange(of: canvasSize) { oldSize, newSize in
             // キャンバスの初回レンダリング時（.zero → 実サイズ）にウィジェット同期を実行。
@@ -765,6 +779,17 @@ struct BoardEditorView: View {
         board.updatedAt = Date()
         try? modelContext.save()
         debouncedSyncBoardToWidget()
+    }
+
+    /// 800ms デバウンスで saveBoard() を呼び出す。
+    /// ジェスチャー実行中のクラッシュや onChange の連続発火に対する安全網として機能する。
+    private func scheduleAutoSave() {
+        autoSaveTask?.cancel()
+        autoSaveTask = Task { @MainActor in
+            try? await Task.sleep(for: .milliseconds(800))
+            guard !Task.isCancelled else { return }
+            saveBoard()
+        }
     }
 
     /// ウィジェット同期をデバウンスして実行する。

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -235,6 +235,11 @@ struct BoardEditorView: View {
             // .background に遷移しないケースでもデータを保護する
             if newPhase == .background || newPhase == .inactive {
                 saveBoard()
+                // saveBoard() 内の debouncedSyncBoardToWidget() は 500ms の遅延があるため、
+                // バックグラウンド移行時はサスペンドまでの時間内に同期を開始できるよう直接呼び出す
+                if newPhase == .background {
+                    syncBoardToWidget()
+                }
             }
         }
         .onChange(of: placements) { _, _ in

--- a/StickerBoardTests/BoardEditorAutoSaveTests.swift
+++ b/StickerBoardTests/BoardEditorAutoSaveTests.swift
@@ -36,10 +36,12 @@ struct BoardEditorAutoSaveTests {
 
     @Test func backgroundへの移行時にsaveBoardが呼ばれる() throws {
         let content = try editorContent
-        // .background ケースで saveBoard() を呼ぶ onChange が存在する
-        let hasBackgroundSave = content.contains(".background") && content.contains("onChange(of: scenePhase")
-        #expect(hasBackgroundSave,
-                "scenePhase が .background になったときの saveBoard() 呼び出しが見つかりません")
+        // .background または .inactive ケースで saveBoard() を呼ぶ onChange が存在する
+        let hasScenePhaseOnChange = content.contains("onChange(of: scenePhase")
+        let hasBackgroundCase = content.contains(".background")
+        let hasInactiveCase = content.contains(".inactive")
+        #expect(hasScenePhaseOnChange && hasBackgroundCase && hasInactiveCase,
+                "scenePhase が .background/.inactive になったときの saveBoard() 呼び出しが見つかりません")
     }
 
     // MARK: - 層2: onChange + デバウンス800ms

--- a/StickerBoardTests/BoardEditorAutoSaveTests.swift
+++ b/StickerBoardTests/BoardEditorAutoSaveTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import Foundation
+
+/// ボード編集画面の自動保存機能テスト
+/// Issue #222: ボードの編集の際に自動保存されるように
+///
+/// 注意: このテストはソースコードを文字列として読み込み、パターンマッチで構造を検証します。
+/// BoardEditorView.swift のメソッド名・構造が変更された場合、
+/// テストのパターンマッチを実態に合わせて更新してください。
+struct BoardEditorAutoSaveTests {
+
+    // MARK: - ファイル読み込みヘルパー
+
+    private var projectRootURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()   // StickerBoardTests/
+            .deletingLastPathComponent()   // project root
+    }
+
+    private func readFile(_ relativePath: String) throws -> String {
+        let url = projectRootURL.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private var editorContent: String {
+        get throws { try readFile("StickerBoard/Views/Board/BoardEditorView.swift") }
+    }
+
+    // MARK: - 層1: scenePhase による保存
+
+    @Test func scenePhase環境変数が定義されている() throws {
+        let content = try editorContent
+        #expect(content.contains("scenePhase"),
+                "scenePhase 環境変数が BoardEditorView に追加されていません")
+    }
+
+    @Test func backgroundへの移行時にsaveBoardが呼ばれる() throws {
+        let content = try editorContent
+        // .background ケースで saveBoard() を呼ぶ onChange が存在する
+        let hasBackgroundSave = content.contains(".background") && content.contains("onChange(of: scenePhase")
+        #expect(hasBackgroundSave,
+                "scenePhase が .background になったときの saveBoard() 呼び出しが見つかりません")
+    }
+
+    // MARK: - 層2: onChange + デバウンス800ms
+
+    @Test func autoSaveTaskが状態変数として定義されている() throws {
+        let content = try editorContent
+        #expect(content.contains("autoSaveTask"),
+                "autoSaveTask 状態変数が BoardEditorView に追加されていません")
+    }
+
+    @Test func scheduleAutoSave関数が定義されている() throws {
+        let content = try editorContent
+        #expect(content.contains("func scheduleAutoSave()"),
+                "scheduleAutoSave() 関数が BoardEditorView に定義されていません")
+    }
+
+    @Test func scheduleAutoSaveが800msデバウンスを実装している() throws {
+        let content = try editorContent
+        guard let range = content.range(of: "func scheduleAutoSave()") else {
+            Issue.record("scheduleAutoSave() 関数が見つかりません")
+            return
+        }
+        // 関数の後の500文字以内に800msのデバウンス処理があることを確認
+        let endIndex = content.index(range.lowerBound, offsetBy: 500, limitedBy: content.endIndex) ?? content.endIndex
+        let body = String(content[range.lowerBound..<endIndex])
+        #expect(body.contains("800"),
+                "scheduleAutoSave() に 800ms のデバウンスが実装されていません")
+    }
+
+    @Test func scheduleAutoSaveがsaveBoardを呼ぶ() throws {
+        let content = try editorContent
+        guard let range = content.range(of: "func scheduleAutoSave()") else {
+            Issue.record("scheduleAutoSave() 関数が見つかりません")
+            return
+        }
+        let endIndex = content.index(range.lowerBound, offsetBy: 500, limitedBy: content.endIndex) ?? content.endIndex
+        let body = String(content[range.lowerBound..<endIndex])
+        #expect(body.contains("saveBoard()"),
+                "scheduleAutoSave() 内で saveBoard() が呼ばれていません")
+    }
+
+    @Test func placementsの変更でscheduleAutoSaveが呼ばれる() throws {
+        let content = try editorContent
+        #expect(content.contains("onChange(of: placements)"),
+                "placements の変更を監視する onChange が見つかりません")
+    }
+
+    @Test func backgroundConfigの変更でscheduleAutoSaveが呼ばれる() throws {
+        let content = try editorContent
+        #expect(content.contains("onChange(of: backgroundConfig)"),
+                "backgroundConfig の変更を監視する onChange が見つかりません")
+    }
+
+    // MARK: - onDisappear でのタスクキャンセル
+
+    @Test func onDisappearでautoSaveTaskがキャンセルされる() throws {
+        let content = try editorContent
+        guard let disappearRange = content.range(of: ".onDisappear") else {
+            Issue.record("onDisappear が見つかりません")
+            return
+        }
+        let endIndex = content.index(disappearRange.lowerBound, offsetBy: 400, limitedBy: content.endIndex) ?? content.endIndex
+        let body = String(content[disappearRange.lowerBound..<endIndex])
+        #expect(body.contains("autoSaveTask?.cancel()"),
+                "onDisappear 内で autoSaveTask?.cancel() が呼ばれていません")
+    }
+}


### PR DESCRIPTION
## Summary

- `scenePhase` 監視でバックグラウンド/非アクティブ移行時に即時保存（層1）
- `placements` / `backgroundConfig` の変更を 800ms デバウンスで自動保存（層2）
- `onDisappear` で保留中の autoSaveTask をキャンセルしてリソースリーク防止

## 背景

ジェスチャー実行中のクラッシュや iOS のバックグラウンド強制終了で `onDisappear` が呼ばれない場合、直前の変更が失われる問題への対策。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `BoardEditorView.swift` | `scenePhase` 環境変数・`autoSaveTask`・`scheduleAutoSave()` を追加。`.onChange` modifier を3つ追加 |
| `BoardEditorAutoSaveTests.swift` | 自動保存機能の構造テストを新規追加（9テストケース） |

## Test plan

- [x] `BoardEditorAutoSaveTests` 9テストケースが全て pass
- [x] 全体テストスイート（465テスト）が pass（LocalizationTests の既存失敗は今回と無関係）
- [ ] 実機でボード編集中にホームボタン → アプリ復帰後に変更が保持されていることを確認
- [ ] 実機でボード編集中に別アプリ起動 → 復帰後に変更が保持されていることを確認

close #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)