### PR TITLE
fix: マスク手動編集の描画レイテンシを解消 (#230)

### DIFF
--- a/StickerBoard.xcodeproj/project.pbxproj
+++ b/StickerBoard.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		71630AD405448E0B887E9228 /* HolographicAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E3E385C3511299350E1EDC0 /* HolographicAccessibilityTests.swift */; };
 		720B355DF1F2E16DA0D57E85 /* CameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B41B23D775F8487A3B361B /* CameraView.swift */; };
 		73FA13E3158C1F1BDACB6C08 /* MotionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE45BBB2C51CC68C9B0C8EBB /* MotionManager.swift */; };
+		741C884F3B6DBBA75BA6A2A3 /* MaskEditorPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3DC004814FD6C09BFF72301 /* MaskEditorPerformanceTests.swift */; };
 		79F486B12087DEA652D55542 /* FirebaseCrashlyticsSetupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97AF12BF2EFB04266319388A /* FirebaseCrashlyticsSetupTests.swift */; };
 		7E45C94C77E1094823F063FC /* BoardEditorZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8391189EB4CBD1967797D83E /* BoardEditorZoomTests.swift */; };
 		8124DEAC93C46FA70F835CF0 /* SharedCIContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C94311FE1E30296BB608F927 /* SharedCIContext.swift */; };
@@ -253,6 +254,7 @@
 		DFE93838BF2C08278A3401AE /* ImageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageStorage.swift; sourceTree = "<group>"; };
 		E0CBD991C7FF69642BB7A6AE /* MultipeerConnectivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipeerConnectivityTests.swift; sourceTree = "<group>"; };
 		E24D931F5239EB34E8311209 /* MultiStickerSelectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiStickerSelectionView.swift; sourceTree = "<group>"; };
+		E3DC004814FD6C09BFF72301 /* MaskEditorPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaskEditorPerformanceTests.swift; sourceTree = "<group>"; };
 		E5D9FFAB2F480D8D2327E386 /* BackgroundRemover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundRemover.swift; sourceTree = "<group>"; };
 		EB005F042AEE62F5E35C66E2 /* BoardEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorView.swift; sourceTree = "<group>"; };
 		EF3C9D7666FCCC1875EBD61B /* FilterBorderAccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterBorderAccessibilityTests.swift; sourceTree = "<group>"; };
@@ -530,6 +532,7 @@
 				D2E37E2FABECAE9B23C7CF61 /* KeychainHelperTests.swift */,
 				4939209FC57BA497E419A77C /* LocalizationTests.swift */,
 				82762278F79270BA92FD3D38 /* MaskCompositorTests.swift */,
+				E3DC004814FD6C09BFF72301 /* MaskEditorPerformanceTests.swift */,
 				E0CBD991C7FF69642BB7A6AE /* MultipeerConnectivityTests.swift */,
 				EF8707E62DE974CFCF4EBA7F /* MultiStickerSelectionAccessibilityTests.swift */,
 				C772005BADEC8B242A0A39E8 /* OnboardingAccessibilityTests.swift */,
@@ -783,6 +786,7 @@
 				6E80A247DC5FCB47A37C937C /* KeychainHelperTests.swift in Sources */,
 				BB3A553CDC3D465634997BD1 /* LocalizationTests.swift in Sources */,
 				2B1517B2E5E84806CB242F6C /* MaskCompositorTests.swift in Sources */,
+				741C884F3B6DBBA75BA6A2A3 /* MaskEditorPerformanceTests.swift in Sources */,
 				A282C9579FE88F9AAA4AAB8E /* MultiStickerSelectionAccessibilityTests.swift in Sources */,
 				F890DFFA9DE2648E4FAB3C3D /* MultipeerConnectivityTests.swift in Sources */,
 				0AB95DB882B4D5509D6E229E /* OnboardingAccessibilityTests.swift in Sources */,

--- a/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
+++ b/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
@@ -181,6 +181,7 @@ class MaskCanvasContainerView: UIView {
 class MaskOverlayView: UIView {
     private var cachedInvertedMask: CGImage?
     private static let ciContext = CIContext(options: [.useSoftwareRenderer: false])
+    private static let invertFilter: CIFilter = CIFilter(name: "CIColorInvert")!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -214,9 +215,8 @@ class MaskOverlayView: UIView {
 
     private func invertMask(_ mask: CGImage) -> CGImage? {
         let ciImage = CIImage(cgImage: mask)
-        guard let filter = CIFilter(name: "CIColorInvert") else { return nil }
-        filter.setValue(ciImage, forKey: kCIInputImageKey)
-        guard let output = filter.outputImage else { return nil }
+        Self.invertFilter.setValue(ciImage, forKey: kCIInputImageKey)
+        guard let output = Self.invertFilter.outputImage else { return nil }
         return Self.ciContext.createCGImage(output, from: output.extent)
     }
 }
@@ -230,8 +230,6 @@ class MaskCanvasUIView: UIView {
     private weak var coordinator: MaskDrawingCanvas.Coordinator?
     weak var maskOverlayView: MaskOverlayView?
     private var lastPoint: CGPoint?
-    private var needsOverlayUpdate = false
-    private var displayLink: CADisplayLink?
     private var isExternalUpdate = false
 
     init(imageSize: CGSize, initialMask: UIImage, coordinator: MaskDrawingCanvas.Coordinator) {
@@ -248,39 +246,10 @@ class MaskCanvasUIView: UIView {
         accessibilityHint = String(localized: "指でなぞってマスクを編集します。2本指でズームやスクロールができます")
 
         setupMaskContext(with: initialMask)
-        setupDisplayLink()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        displayLink?.invalidate()
-    }
-
-    override func willMove(toWindow newWindow: UIWindow?) {
-        super.willMove(toWindow: newWindow)
-        if newWindow == nil {
-            displayLink?.invalidate()
-            displayLink = nil
-        } else if displayLink == nil {
-            setupDisplayLink()
-        }
-    }
-
-    private func setupDisplayLink() {
-        displayLink = CADisplayLink(target: self, selector: #selector(displayLinkFired))
-        displayLink?.preferredFrameRateRange = CAFrameRateRange(minimum: 15, maximum: 30)
-        displayLink?.add(to: .main, forMode: .common)
-    }
-
-    @objc private func displayLinkFired() {
-        guard needsOverlayUpdate else { return }
-        needsOverlayUpdate = false
-        if let cgImage = maskContext?.makeImage() {
-            maskOverlayView?.updateMask(cgImage)
-        }
     }
 
     private func setupMaskContext(with mask: UIImage) {
@@ -324,47 +293,50 @@ class MaskCanvasUIView: UIView {
 
     override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
         guard let touch = touches.first, let ctx = maskContext else { return }
-        let currentPoint = touch.location(in: self)
-        let previousPoint = lastPoint ?? currentPoint
 
         let brushRadius = coordinator?.brushSize ?? 30
         let isEraser = coordinator?.brushMode == .eraser
-
         let viewToImageX = imageSize.width / bounds.width
         let viewToImageY = imageSize.height / bounds.height
-
-        let imgPrevious = CGPoint(x: previousPoint.x * viewToImageX, y: (bounds.height - previousPoint.y) * viewToImageY)
-        let imgCurrent = CGPoint(x: currentPoint.x * viewToImageX, y: (bounds.height - currentPoint.y) * viewToImageY)
         let imgBrushRadius = brushRadius * viewToImageX
-
         let grayValue: CGFloat = isEraser ? 0.0 : 1.0
         ctx.setFillColor(gray: grayValue, alpha: 1.0)
 
-        let distance = hypot(imgCurrent.x - imgPrevious.x, imgCurrent.y - imgPrevious.y)
-        let step = max(imgBrushRadius * 0.3, 1.0)
-        let steps = max(Int(distance / step), 1)
+        // coalescedTouches で間引かれたタッチポイントをすべて処理しストロークを滑らかにする
+        let touchesToProcess = event?.coalescedTouches(for: touch) ?? [touch]
+        for coalescedTouch in touchesToProcess {
+            let currentPoint = coalescedTouch.location(in: self)
+            let previousPoint = lastPoint ?? currentPoint
 
-        for i in 0...steps {
-            let t = CGFloat(i) / CGFloat(steps)
-            let x = imgPrevious.x + (imgCurrent.x - imgPrevious.x) * t
-            let y = imgPrevious.y + (imgCurrent.y - imgPrevious.y) * t
-            let rect = CGRect(
-                x: x - imgBrushRadius,
-                y: y - imgBrushRadius,
-                width: imgBrushRadius * 2,
-                height: imgBrushRadius * 2
-            )
-            ctx.fillEllipse(in: rect)
+            let imgPrevious = CGPoint(x: previousPoint.x * viewToImageX, y: (bounds.height - previousPoint.y) * viewToImageY)
+            let imgCurrent = CGPoint(x: currentPoint.x * viewToImageX, y: (bounds.height - currentPoint.y) * viewToImageY)
+
+            let distance = hypot(imgCurrent.x - imgPrevious.x, imgCurrent.y - imgPrevious.y)
+            let step = max(imgBrushRadius * 0.3, 1.0)
+            let steps = max(Int(distance / step), 1)
+
+            for i in 0...steps {
+                let t = CGFloat(i) / CGFloat(steps)
+                let x = imgPrevious.x + (imgCurrent.x - imgPrevious.x) * t
+                let y = imgPrevious.y + (imgCurrent.y - imgPrevious.y) * t
+                ctx.fillEllipse(in: CGRect(x: x - imgBrushRadius, y: y - imgBrushRadius,
+                                           width: imgBrushRadius * 2, height: imgBrushRadius * 2))
+            }
+
+            lastPoint = currentPoint
         }
 
-        lastPoint = currentPoint
-        needsOverlayUpdate = true
+        // 直接更新することでタッチ→描画反映のレイテンシをゼロにする
+        updateOverlayFromMask()
+    }
+
+    private func updateOverlayFromMask() {
+        guard let cgImage = maskContext?.makeImage() else { return }
+        maskOverlayView?.updateMask(cgImage)
     }
 
     override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
         lastPoint = nil
-        // 最終フレームを即座に反映
-        needsOverlayUpdate = false
         if let cgImage = maskContext?.makeImage() {
             maskOverlayView?.updateMask(cgImage)
             delegate?.canvasStrokeCompleted(mask: UIImage(cgImage: cgImage))

--- a/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
+++ b/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
@@ -181,7 +181,7 @@ class MaskCanvasContainerView: UIView {
 class MaskOverlayView: UIView {
     private var cachedInvertedMask: CGImage?
     private static let ciContext = CIContext(options: [.useSoftwareRenderer: false])
-    private static let invertFilter: CIFilter = CIFilter(name: "CIColorInvert")!
+    private let invertFilter: CIFilter = CIFilter(name: "CIColorInvert")!
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -215,8 +215,8 @@ class MaskOverlayView: UIView {
 
     private func invertMask(_ mask: CGImage) -> CGImage? {
         let ciImage = CIImage(cgImage: mask)
-        Self.invertFilter.setValue(ciImage, forKey: kCIInputImageKey)
-        guard let output = Self.invertFilter.outputImage else { return nil }
+        invertFilter.setValue(ciImage, forKey: kCIInputImageKey)
+        guard let output = invertFilter.outputImage else { return nil }
         return Self.ciContext.createCGImage(output, from: output.extent)
     }
 }

--- a/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
+++ b/StickerBoard/Views/Capture/MaskDrawingCanvas.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import CoreImage.CIFilterBuiltins
 
 // MARK: - ブラシモード
 
@@ -181,7 +182,7 @@ class MaskCanvasContainerView: UIView {
 class MaskOverlayView: UIView {
     private var cachedInvertedMask: CGImage?
     private static let ciContext = CIContext(options: [.useSoftwareRenderer: false])
-    private let invertFilter: CIFilter = CIFilter(name: "CIColorInvert")!
+    private let invertFilter = CIFilter.colorInvert()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -214,8 +215,7 @@ class MaskOverlayView: UIView {
     }
 
     private func invertMask(_ mask: CGImage) -> CGImage? {
-        let ciImage = CIImage(cgImage: mask)
-        invertFilter.setValue(ciImage, forKey: kCIInputImageKey)
+        invertFilter.inputImage = CIImage(cgImage: mask)
         guard let output = invertFilter.outputImage else { return nil }
         return Self.ciContext.createCGImage(output, from: output.extent)
     }

--- a/StickerBoardTests/MaskEditorPerformanceTests.swift
+++ b/StickerBoardTests/MaskEditorPerformanceTests.swift
@@ -92,11 +92,16 @@ struct MaskEditorPerformanceTests {
 
     // MARK: - CIFilter キャッシュ
 
-    @Test func invertFilterがstaticキャッシュされていること() throws {
+    @Test func invertFilterがインスタンスプロパティとしてキャッシュされていること() throws {
         let content = try canvasContent
+        // CIFilter はスレッドセーフでないため static 共有は禁止。インスタンスプロパティとしてキャッシュする
         #expect(
-            content.contains("static let invertFilter") || content.contains("static var invertFilter"),
-            "MaskOverlayView.invertFilter が static プロパティになっていません。毎フレームの CIFilter 生成コストを排除するために static キャッシュが必要です"
+            content.contains("let invertFilter") || content.contains("var invertFilter"),
+            "MaskOverlayView.invertFilter がインスタンスプロパティとしてキャッシュされていません。毎フレームの CIFilter 生成コストを排除するためにインスタンスキャッシュが必要です"
+        )
+        #expect(
+            !content.contains("static let invertFilter") && !content.contains("static var invertFilter"),
+            "CIFilter は NSObject のミュータブルサブクラスでスレッドセーフではないため static 共有は禁止です"
         )
     }
 }

--- a/StickerBoardTests/MaskEditorPerformanceTests.swift
+++ b/StickerBoardTests/MaskEditorPerformanceTests.swift
@@ -60,7 +60,10 @@ struct MaskEditorPerformanceTests {
 
     @Test func touchesMovedでupdateOverlayFromMaskが呼ばれること() throws {
         let content = try canvasContent
-        // touchesMoved 内の本体を抽出して確認
+        // 注意: 中括弧カウントによるスコープ特定は実装変更に弱い脆弱なパターンです。
+        // このテストが予期せず失敗した場合は、touchesMoved のシグネチャや
+        // メソッドのネスト構造が変わっていないか MaskDrawingCanvas.swift を確認してください。
+        // プロジェクトの慣習（ソースコード文字列解析）に従い、このパターンを採用しています。
         let range = try #require(content.range(of: "func touchesMoved("),
                                  "touchesMoved が見つかりません")
         let fromMoved = content[range.lowerBound...]

--- a/StickerBoardTests/MaskEditorPerformanceTests.swift
+++ b/StickerBoardTests/MaskEditorPerformanceTests.swift
@@ -1,0 +1,102 @@
+import Testing
+import Foundation
+
+/// マスク手動編集画面の描画パフォーマンステスト
+/// Issue #230: シールの背景除去を手動でする際のパフォーマンスアップ
+///
+/// ## 問題の背景
+/// MaskCanvasUIView がCADisplayLinkで最大30fps制限のオーバーレイ更新を行っていたため、
+/// touchesMoved から描画反映まで最大67msの遅延が発生していた。
+/// また MaskOverlayView.invertMask() で毎フレーム新規 CIFilter を生成していたためコストが高かった。
+///
+/// ## 修正方針
+/// - CADisplayLink を廃止し、touchesMoved で直接 updateOverlayFromMask() を呼び出す
+/// - CIFilter をstaticプロパティにキャッシュして再生成コストを排除する
+/// - coalescedTouches を利用してストロークの精度を向上させる
+///
+/// 注意: このテストはソースコードを文字列として読み込み、パターンマッチで構造を検証します。
+/// MaskDrawingCanvas.swift のメソッド名・構造が変更された場合、
+/// テストのパターンマッチを実態に合わせて更新してください。
+struct MaskEditorPerformanceTests {
+
+    // MARK: - ファイル読み込みヘルパー
+
+    private var projectRootURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func readFile(_ relativePath: String) throws -> String {
+        let url = projectRootURL.appendingPathComponent(relativePath)
+        return try String(contentsOf: url, encoding: .utf8)
+    }
+
+    private var canvasContent: String {
+        get throws { try readFile("StickerBoard/Views/Capture/MaskDrawingCanvas.swift") }
+    }
+
+    // MARK: - CADisplayLink 廃止
+
+    @Test func CADisplayLinkが使用されていないこと() throws {
+        let content = try canvasContent
+        #expect(!content.contains("CADisplayLink"),
+                "CADisplayLinkはオーバーレイ更新の遅延原因です。touchesMovedで直接updateOverlayFromMask()を呼ぶ方式に変更してください")
+    }
+
+    @Test func needsOverlayUpdateフラグが存在しないこと() throws {
+        let content = try canvasContent
+        #expect(!content.contains("needsOverlayUpdate"),
+                "needsOverlayUpdateフラグはCADisplayLink方式の残骸です。直接更新方式では不要です")
+    }
+
+    // MARK: - 直接オーバーレイ更新
+
+    @Test func updateOverlayFromMask関数が定義されていること() throws {
+        let content = try canvasContent
+        #expect(content.contains("func updateOverlayFromMask()"),
+                "touchesMovedから呼ぶ直接更新ヘルパー updateOverlayFromMask() が定義されていません")
+    }
+
+    @Test func touchesMovedでupdateOverlayFromMaskが呼ばれること() throws {
+        let content = try canvasContent
+        // touchesMoved 内の本体を抽出して確認
+        let range = try #require(content.range(of: "func touchesMoved("),
+                                 "touchesMoved が見つかりません")
+        let fromMoved = content[range.lowerBound...]
+        var braceCount = 0
+        var endIndex = fromMoved.startIndex
+        var started = false
+        for idx in fromMoved.indices {
+            if fromMoved[idx] == "{" {
+                braceCount += 1
+                started = true
+            } else if fromMoved[idx] == "}" {
+                braceCount -= 1
+            }
+            endIndex = idx
+            if started && braceCount == 0 { break }
+        }
+        let body = String(fromMoved[fromMoved.startIndex...endIndex])
+        #expect(body.contains("updateOverlayFromMask()"),
+                "touchesMoved内でupdateOverlayFromMask()が呼ばれていません。直接更新でレイテンシを排除してください")
+    }
+
+    // MARK: - coalescedTouches によるストローク精度向上
+
+    @Test func coalescedTouchesが使用されていること() throws {
+        let content = try canvasContent
+        #expect(content.contains("coalescedTouches"),
+                "coalescedTouches が使用されていません。UIEvent.coalescedTouches(for:) でストロークの精度を向上させてください")
+    }
+
+    // MARK: - CIFilter キャッシュ
+
+    @Test func invertFilterがstaticキャッシュされていること() throws {
+        let content = try canvasContent
+        #expect(
+            content.contains("static let invertFilter") || content.contains("static var invertFilter"),
+            "MaskOverlayView.invertFilter が static プロパティになっていません。毎フレームの CIFilter 生成コストを排除するために static キャッシュが必要です"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- `CADisplayLink`（最大30fps）を廃止し、`touchesMoved` で `updateOverlayFromMask()` を直接呼び出す方式に変更してタッチ→描画反映のレイテンシをゼロにした
- `event.coalescedTouches(for:)` を使用して、システムが間引いたタッチポイントをすべて処理しストロークをなめらかにした
- `CIFilter` をインスタンスプロパティとしてキャッシュし、毎フレームの生成コストを削減（static 共有はスレッドセーフでないため回避）

## Before / After

| | Before | After |
|---|---|---|
| 更新方式 | CADisplayLink (15–30fps、最大67ms遅延) | touchesMoved から直接更新（遅延ゼロ） |
| ストローク精度 | 一部タッチポイントを補間のみ | coalescedTouches で全ポイントを処理 |
| CIFilter | 毎フレーム new | インスタンスキャッシュ |

## Test plan

- [ ] 実機でマスク手動編集画面を開き、指でなぞると即座に赤いオーバーレイが追従することを確認
- [ ] 消しゴム／復元の両モードで遅延がないことを確認
- [ ] ピンチでズームしてからなぞっても正常に描画されることを確認
- [ ] Undoが正常に動作すること（ストローク開始前の状態に戻ること）を確認
- [ ] `MaskEditorPerformanceTests` 6件すべてがパスすること

close #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)