### PR TITLE
fix: ボードエディタのインラインライブラリでシール追加ボタンが機能しないバグを修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ open StickerBoard.xcodeproj
 - ImageStorage.rotateAndOverwrite(fileName:clockwise:) はディスクからの読み込み → UIImage.rotatedBy90Degrees(clockwise:) で90度回転 → overwrite() の順で処理する。回転メソッドは ImageCacheManager.swift の UIImage 拡張に定義。UIGraphicsImageRendererFormat.scale に元画像のスケールを引き継がないとピクセル寸法が変わるため注意
 - ImageStorageError には encodingFailed / deletionFailed / loadFailed の3ケースあり。loadFailed は rotateAndOverwrite で対象ファイルが見つからない場合に投げる
 - StickerLibraryView は @Query ではなく FetchDescriptor + fetchLimit/fetchOffset によるページネーション（30枚ずつ無限スクロール）でシールを取得する設計（大量シール時のメモリ最適化）
-- StickerLibraryView はピッカーモード対応（`onStickerPicked: ((Sticker) -> Void)? = nil`）。nil 以外のとき、シールタップでコールバックを呼び出しプレビュー/コンテキストメニュー/さらに追加カードを非表示にする。BoardEditorView の「追加」ボタン → `.sheet(isPresented: $showingInlineLibrary)` でピッカーモードのライブラリをボトムシート表示し、選択後にシールをボード中央に配置して自動クローズする
+- StickerLibraryView はピッカーモード対応（`onStickerPicked: ((Sticker) -> Void)? = nil`）。nil 以外のとき、シールタップでコールバックを呼び出しプレビュー/コンテキストメニュー/グリッド先頭の「さらに追加」カードを非表示にする。空の状態で表示される「シールを追加する」ボタンは `onAddSticker` コールバックで制御（ピッカーモードでも有効）。BoardEditorView の「追加」ボタン → `.sheet(isPresented: $showingInlineLibrary)` でピッカーモードのライブラリをボトムシート表示し、選択後にシールをボード中央に配置して自動クローズする。シール0枚時に「シールを追加する」をタップするとライブラリを閉じて `StickerCaptureView` を表示し、保存後に `showingInlineLibrary = true` でライブラリを再表示する（`pendingOpenCapture` / `stickerSavedInCapture` フラグで SwiftUI の同一階層シート制約を回避）
 - サムネイル表示（StickerThumbnailView, BoardStickerPreviewView）は ImageStorage.loadThumbnail() 経由で縮小画像を使用
 - 枠線（ボーダー）は StickerPlacement の borderWidthType / borderColorHex に保存し、フィルターと同様に配置単位で管理する設計
 - シールロックは StickerPlacement の isLocked: Bool = false に保存（旧データとの後方互換性: decodeIfPresent でデフォルト false）。ロック中はドラッグ・ピンチ・回転ジェスチャーおよび効果・枠線・前面・背面・削除ボタンを無効化。VoiceOver はロック/解除アクション + UIAccessibility.post アナウンス対応

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -180,7 +180,8 @@ struct BoardEditorView: View {
         .sheet(isPresented: $showingInlineLibrary, onDismiss: {
             if pendingOpenCapture {
                 pendingOpenCapture = false
-                Task { showingCapture = true }
+                // dismiss アニメーションとの競合を防ぐため次のメインループで表示
+                Task { @MainActor in showingCapture = true }
             }
         }) {
             NavigationStack {
@@ -201,14 +202,16 @@ struct BoardEditorView: View {
         .sheet(isPresented: $showingCapture, onDismiss: {
             if stickerSavedInCapture {
                 stickerSavedInCapture = false
+                // showingCapture が true の間に更新すると onChange が発火しないため onDismiss で行う
                 inlineLibraryRefreshTrigger = UUID()
-                Task { showingInlineLibrary = true }
+                // dismiss アニメーションとの競合を防ぐため次のメインループで表示
+                Task { @MainActor in showingInlineLibrary = true }
             }
         }) {
             NavigationStack {
                 StickerCaptureView(onStickerSaved: {
                     stickerSavedInCapture = true
-                    Task {
+                    Task { @MainActor in
                         await UnplacedStickerReminderService.shared.rescheduleIfNeeded(context: modelContext)
                     }
                 })

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -33,6 +33,9 @@ struct BoardEditorView: View {
     @State private var hasPerformedInitialSync = false
     @State private var undoStack: [(placements: [StickerPlacement], backgroundConfig: BackgroundPatternConfig)] = []
     @State private var autoSaveTask: Task<Void, Never>?
+    @State private var showingCapture = false
+    @State private var pendingOpenCapture = false
+    @State private var stickerSavedInCapture = false
 
     // ズームモード
     @State private var isZoomMode: Bool = false
@@ -174,10 +177,19 @@ struct BoardEditorView: View {
                 .accessibilityLabel(String(localized: "その他のアクション"))
             }
         }
-        .sheet(isPresented: $showingInlineLibrary) {
+        .sheet(isPresented: $showingInlineLibrary, onDismiss: {
+            if pendingOpenCapture {
+                pendingOpenCapture = false
+                showingCapture = true
+            }
+        }) {
             NavigationStack {
                 StickerLibraryView(
                     refreshTrigger: inlineLibraryRefreshTrigger,
+                    onAddSticker: {
+                        pendingOpenCapture = true
+                        showingInlineLibrary = false
+                    },
                     onStickerPicked: { sticker in
                         addStickerToBoard(sticker)
                         showingInlineLibrary = false
@@ -185,6 +197,19 @@ struct BoardEditorView: View {
                 )
             }
             .presentationDetents([.medium, .large])
+        }
+        .sheet(isPresented: $showingCapture, onDismiss: {
+            if stickerSavedInCapture {
+                stickerSavedInCapture = false
+                showingInlineLibrary = true
+            }
+        }) {
+            NavigationStack {
+                StickerCaptureView(onStickerSaved: {
+                    inlineLibraryRefreshTrigger = UUID()
+                    stickerSavedInCapture = true
+                })
+            }
         }
         .sheet(isPresented: $showingBackgroundPicker, onDismiss: {
             board.backgroundPattern = backgroundConfig

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -201,13 +201,17 @@ struct BoardEditorView: View {
         .sheet(isPresented: $showingCapture, onDismiss: {
             if stickerSavedInCapture {
                 stickerSavedInCapture = false
+                // onDismiss でトリガーすることで、ライブラリが表示中に onChange が確実に発火する
+                inlineLibraryRefreshTrigger = UUID()
                 showingInlineLibrary = true
             }
         }) {
             NavigationStack {
                 StickerCaptureView(onStickerSaved: {
-                    inlineLibraryRefreshTrigger = UUID()
                     stickerSavedInCapture = true
+                    Task {
+                        await UnplacedStickerReminderService.shared.rescheduleIfNeeded(context: modelContext)
+                    }
                 })
             }
         }
@@ -273,6 +277,8 @@ struct BoardEditorView: View {
             updateTask?.cancel()
             widgetSyncTask?.cancel()
             widgetSyncDebounceTask?.cancel()
+            pendingOpenCapture = false
+            stickerSavedInCapture = false
             board.placements = placements
             board.updatedAt = Date()
             try? modelContext.save()

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -180,7 +180,7 @@ struct BoardEditorView: View {
         .sheet(isPresented: $showingInlineLibrary, onDismiss: {
             if pendingOpenCapture {
                 pendingOpenCapture = false
-                showingCapture = true
+                Task { showingCapture = true }
             }
         }) {
             NavigationStack {
@@ -201,9 +201,8 @@ struct BoardEditorView: View {
         .sheet(isPresented: $showingCapture, onDismiss: {
             if stickerSavedInCapture {
                 stickerSavedInCapture = false
-                // onDismiss でトリガーすることで、ライブラリが表示中に onChange が確実に発火する
                 inlineLibraryRefreshTrigger = UUID()
-                showingInlineLibrary = true
+                Task { showingInlineLibrary = true }
             }
         }) {
             NavigationStack {


### PR DESCRIPTION
## 原因

`BoardEditorView` のインラインライブラリ（ピッカーモード）では `onAddSticker` コールバックが渡されておらず、デフォルトの空クロージャ `{}` のままでした。

そのため、シールが0枚のときに表示される「シールを追加する」ボタンを押しても何も起きず、写真選択・カメラ撮影の画面が表示されませんでした。

## 修正内容

- `BoardEditorView` に `showingCapture`・`pendingOpenCapture`・`stickerSavedInCapture` の3つの状態変数を追加
- インラインライブラリのシートに `onAddSticker` を渡し、押下時にライブラリを閉じてキャプチャ画面を表示するよう修正
- キャプチャ画面でシールを保存後、自動的にインラインライブラリを再表示してすぐに選択できるよう改善
- シートの連鎖は `onDismiss` コールバックで制御（SwiftUI の sheet 二重表示問題を回避）

## 再現手順（修正前）

1. ボードを開く
2. シールが0枚の状態でツールバーの「追加」ボタンをタップ
3. ライブラリが開き「シールを追加する」ボタンが表示される
4. ボタンをタップ → **何も起きない（バグ）**

## 修正後の動作

4. ボタンをタップ → ライブラリが閉じ、シール撮影画面（カメラ/写真の選択）が表示される
5. シール保存後 → 自動的にライブラリが再表示され、追加したシールをすぐにボードに配置できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)