### PR TITLE
feat: Google AdMob 統合 - 無料ユーザー向け広告表示 (#258-#261)

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -10,6 +10,16 @@
       "env": {
         "FIREBASE_PROJECT_ID": "stickerboard-5987a"
       }
+    },
+    "pencil": {
+      "name": "pencil",
+      "transport": "stdio",
+      "command": "/Users/tebasakin/.pencil/mcp/visual_studio_code/out/mcp-server-darwin-arm64",
+      "args": [
+        "--app",
+        "visual_studio_code"
+      ],
+      "env": {}
     }
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,12 +17,12 @@
 StickerBoard/
 ├── App/          # エントリーポイント（MainTabView）、カラーテーマ、外部URL定数
 ├── Models/       # SwiftData モデル（Sticker, Board, StickerPlacement, BackgroundPattern, StickerFilter, StickerBorder, SubscriptionProduct）+ ExchangeMessage（MultipeerConnectivity転送用Codableモデル）
-├── Services/     # BackgroundRemover, MaskCompositor, ImageStorage, BackgroundImageStorage, ImageCacheManager, StickerFilterService, StickerBorderService, SubscriptionManager, MotionManager, AppUpdateChecker, WidgetDataSyncService, ReviewRequestManager, MultipeerConnectivityManager, BoardShareService
+├── Services/     # BackgroundRemover, MaskCompositor, ImageStorage, BackgroundImageStorage, ImageCacheManager, StickerFilterService, StickerBorderService, SubscriptionManager, MotionManager, AppUpdateChecker, WidgetDataSyncService, ReviewRequestManager, MultipeerConnectivityManager, BoardShareService, AdManager
 └── Views/        # SwiftUI画面
     ├── Home/     # MainTabView（タブナビゲーション）、HomeView（ボード一覧カルーセル）
     ├── Onboarding/ # 初回起動オンボーディング（3ページガイド）
     ├── Capture/  # シール撮影・切り抜きフロー・マスク手動編集
-    ├── Library/  # シールライブラリ
+    ├── Library/  # シールライブラリ（StickerLibraryView, NativeAdCard）
     ├── Paywall/  # ペイウォール（Pro課金導線）
     ├── Settings/ # 設定画面（サブスクリプション管理）
     ├── Exchange/ # β版シール交換（MultipeerConnectivity P2P）
@@ -124,4 +124,5 @@ open StickerBoard.xcodeproj
 - Firebase Crashlytics: `StickerBoardApp.init()` の先頭で `FirebaseApp.configure()` を呼び出してクラッシュ検知を初期化。`GoogleService-Info.plist` はFirebaseコンソールからダウンロードして `StickerBoard/` 直下に配置する（.gitignore で除外）。Privacy Manifest（`StickerBoard/PrivacyInfo.xcprivacy`）にクラッシュデータ・パフォーマンスデータ・デバイスIDの申告を記載済み。Claude Code から MCP 経由でクラッシュ分析する方法は `docs/MCP_CRASHLYTICS.md` を参照
 - BoardShareService（`@MainActor enum`）はボードのSNSシェア機能を提供。`presentShareSheet()` は `async` で、`Task.detached { await MainActor.run { ImageRenderer(...); renderer.scale = ...; return renderer.uiImage } }` パターンでレンダリングをメインスレッドのブロックなしに実行する。`saveBoardAsImage()` も同パターン。呼び出し元（`share()` メソッド）は同期のままで内部で `Task { await presentShareSheet() }` を起動する設計
 - MultipeerConnectivity（β版シール交換）: `MultipeerConnectivityManager` が `@MainActor @Observable` シングルトンで MCSession / MCNearbyServiceAdvertiser / MCNearbyServiceBrowser を管理。`ExchangeMessage`（Codable）で画像データを転送し、受信後に `ImageStorage.save()` → SwiftData insert でライブラリに追加。`project.yml` に `NSLocalNetworkUsageDescription` と `NSBonjourServices`（`_stickerboard._tcp`, `_stickerboard._udp`）を追加済み。受信データのバリデーション: JSONペイロード上限 = maxImageDataSize×2（base64オーバーヘッド考慮）、展開後画像サイズ上限 = 10MB の二段階。Settings画面の「β機能」セクションからアクセス可能
+- AdManager（`@Observable @MainActor` シングルトン）が広告表示を一元管理。Pro ユーザーには一切広告を表示しない。`preloadAll()` は ATT 許可確定後に `GADMobileAds.sharedInstance().start()` を呼び出してから広告をプリロードする（StickerBoardApp の `.task` とオンボーディング完了コールバックから呼び出し）。ネイティブ広告（`GADNativeAd`）はシールライブラリグリッドの先頭チャンク後に `NativeAdCard` として挿入。インタースティシャルはエクスポート・写真保存の累計3回ごとに `recordExportAndShowIfNeeded()` で表示。`StickerLibraryView` では `@State private var adManager = AdManager.shared` で保持し（`@Observable` singleton 直接参照は SwiftUI 再レンダリングが発火しない）、`let loadedNativeAd = adManager.nativeAd` を `LazyVStack` 外で参照してオブザベーションを登録する設計。広告ユニット ID は `AdManager.AdUnitID` enum で管理（本番 ID は AdMob コンソールから取得済み）
 - UnplacedStickerReminderService（Sendable シングルトン）が未配置シールのリマインダー通知を管理。未配置シール検出は `detectUnplaced(stickers:boards:)` の純粋ロジック（全 Board の placements.imageFileName に含まれない Sticker を抽出）。毎週土曜 10:00 に `UNCalendarNotificationTrigger(repeats: true)` でスケジュール。通知には `UNNotificationAttachment` でサムネイル画像を添付。通知デリゲートは `NotificationDelegate`（`UIApplicationDelegateAdaptor` 経由）が担い、タップ時に `Notification.Name.openStickerDeepLink` を投稿して `deepLinkStickerId` をセット。Settings画面の「通知」セクションのトグルで ON/OFF 可能。リスケジュールのタイミング: アプリ起動時（StickerBoardApp.body.task）、シール保存後（MainTabView.onStickerSaved）、ボードエディタ内シール保存後（BoardEditorView.onStickerSaved）。`rescheduleIfNeeded(context:defaults:)` は `isEnabled = false` の場合 `cancelNotification()` を呼んで保留通知を削除してから早期リターンする（起動時の残存通知を確実にクリア）。SwiftData フェッチ失敗・通知登録失敗は `Logger(category: "ReminderService")` で `error` レベルログを出力（OSLog）。StickerLibraryView の `highlightStickerId: Binding<UUID?>` でプレビュー表示後に自動 nil リセット

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@
 
 子どもの頃にシール手帳に夢中になった世代が、大人になった今もシール集めの楽しさをスマホで体験できます。
 
+## 関連リンク
+
+### SNS / 発信
+
+| プラットフォーム | URL |
+|---|---|
+| note | https://note.com/colorfreemap |
+
+### 記事
+
+| タイトル | URL | 状態 |
+|---|---|---|
+| アプリ紹介記事（izanami.dev） | https://izanami.dev/post/f02941c4-8a84-4c61-bfbd-43606ed68073 | 公開済み |
+| 開発の思いを書いた note 記事 | （公開後に追記） | 下書き: [`docs/note_article.md`](docs/note_article.md) |
+
+---
+
 ## 機能
 
 - **撮影ガイド** — シール追加画面にきれいに切り抜くための撮影のコツを表示（折りたたみ可能、状態を記憶）
@@ -33,6 +50,7 @@
 - **シール交換 β版** — MultipeerConnectivity（近距離Bluetooth/Wi-Fi P2P）を使って近くのデバイスとシールを交換できるβ版機能。設定画面の「β機能」セクションからアクセス。デバイス検索 → 接続申請 → シール選択 → 送信 → 受信したシールをライブラリに保存する一連のフローをサポート
 - **ボードショーケースウィジェット** — WidgetKit でお気に入りのボードをホーム画面に飾れるウィジェット機能（Small / Medium / Large サイズ対応）。ウィジェット長押しでボード選択、タップでボード編集画面に直接遷移（完全無料）
 - **ウィジェット用ボード** — ボード作成時に「ウィジェット用」タイプを選ぶと、専用比率のキャンバスで編集できる。Large（364×382pt）と Small（正方形）の2種類に対応し、WYSIWYG でホーム画面への表示と一致したレイアウトが可能
+- **広告表示（AdMob）** — 無料ユーザー向けに、シールライブラリ内へのネイティブ広告挿入・エクスポート/写真保存3回ごとのインタースティシャル広告表示に対応。ATT（App Tracking Transparency）ダイアログをオンボーディング完了後に表示。Pro ユーザーには一切広告を表示しない
 - **英語ローカライズ** — 日本語・英語に対応（`Localizable.xcstrings` で管理）。端末言語に合わせて全画面が自動翻訳される
 
 ## 技術スタック
@@ -45,6 +63,7 @@
 | データ保存 | SwiftData + FileManager |
 | 課金 | StoreKit 2（自動更新サブスクリプション） |
 | ウィジェット | WidgetKit + AppIntentConfiguration |
+| 広告 | Google Mobile Ads SDK（AdMob） |
 | クラッシュ検知 | Firebase Crashlytics |
 | プロジェクト管理 | XcodeGen |
 | 対応OS | iOS 18+ |
@@ -160,6 +179,7 @@ StickerBoard/
 │   ├── SubscriptionManager.swift    # StoreKit 2 サブスクリプション管理
 │   ├── AppUpdateChecker.swift       # App Storeバージョンチェック・アップデート通知
 │   ├── WidgetDataSyncService.swift  # ウィジェットへのスナップショット・メタデータ同期
+│   ├── AdManager.swift              # Google AdMob 広告管理（ネイティブ・インタースティシャル、ATT対応）
 │   └── MultipeerConnectivityManager.swift # β版シール交換（P2P近距離通信）
 └── Views/
     ├── Home/
@@ -182,7 +202,8 @@ StickerBoard/
     ├── Paywall/
     │   └── PaywallView.swift         # ペイウォール・ProBadge
     ├── Library/
-    │   └── StickerLibraryView.swift  # シール一覧
+    │   ├── StickerLibraryView.swift  # シール一覧
+    │   └── NativeAdCard.swift        # ネイティブ広告カード（グリッド内挿入用）
     ├── Exchange/
     │   └── StickerExchangeView.swift # β版シール交換（MultipeerConnectivity）
     └── Board/

--- a/StickerBoard.xcodeproj/project.pbxproj
+++ b/StickerBoard.xcodeproj/project.pbxproj
@@ -12,9 +12,11 @@
 		08ADD0896E6540848CAB00C7 /* AppURLs.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE8B7F0F5A52456C43D5F45E /* AppURLs.swift */; };
 		0AB95DB882B4D5509D6E229E /* OnboardingAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C772005BADEC8B242A0A39E8 /* OnboardingAccessibilityTests.swift */; };
 		10EB9C33B64B186C1DA9B7AC /* StickerFilterService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D44F094F53D9CC5028477F0F /* StickerFilterService.swift */; };
+		177F476944E741FA5581B3F5 /* AdManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD283257FAE24DB47C1A31B0 /* AdManager.swift */; };
 		17F2CCB19526F58F4BCC6D04 /* OnboardingPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24DB2CADF1571137158B612F /* OnboardingPageView.swift */; };
 		1A6D5B570ED5466E73AD8176 /* Board.swift in Sources */ = {isa = PBXBuildFile; fileRef = 32104833845A2ADD7C14A5F8 /* Board.swift */; };
 		1B9FD0643BE0A4621A5CFEEF /* SharedBoardMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27912520AF159D0D12135A2C /* SharedBoardMetadata.swift */; };
+		1D6DC7533997985BBF4CB76D /* GoogleMobileAds in Frameworks */ = {isa = PBXBuildFile; productRef = F10C42E0E6C50CAB03CC893B /* GoogleMobileAds */; };
 		1E97A5A5CAE9D4FBC8421696 /* BoardEditorUndoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FC4DAF0371E295F74BAD946 /* BoardEditorUndoTests.swift */; };
 		1EA00AE13C24C07F0760CC5B /* StickerFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3FC7C093763688E6344217F /* StickerFilter.swift */; };
 		239BFA049BCEBDA3E5B04875 /* WidgetModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11C89501ABCC774418176436 /* WidgetModelsTests.swift */; };
@@ -94,6 +96,7 @@
 		C4460E2AC4B0A01446BD3666 /* StickerLibraryAccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B6E414C38C81FDD95EBC2EE /* StickerLibraryAccessibilityTests.swift */; };
 		C872359F958D4BC34AB71FDB /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = D88D0DB2BBA3A6003D7B42C5 /* Localizable.xcstrings */; };
 		C98D76F680578FBA369FBE52 /* AccessibilityRuleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AFDF2A8C549FCAF35D5DD828 /* AccessibilityRuleTests.swift */; };
+		C9BD7806252FFA6680B10E56 /* NativeAdCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91427A0F32409B0DFC58A10F /* NativeAdCard.swift */; };
 		CB5CDB350C326919C148B630 /* SubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 285EEB7B80609E9E695A678B /* SubscriptionProduct.swift */; };
 		CD7F900D42AEFF5E5C1C652F /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F297348DD96E3A76B8648C82 /* SettingsView.swift */; };
 		CEE293526AD847B540BF5EC7 /* BoardListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37C5DFE900836F1D943C5CFB /* BoardListView.swift */; };
@@ -222,6 +225,7 @@
 		8391189EB4CBD1967797D83E /* BoardEditorZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorZoomTests.swift; sourceTree = "<group>"; };
 		89EABB485711FDF3057EB771 /* BoardEditorInlineLibraryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BoardEditorInlineLibraryTests.swift; sourceTree = "<group>"; };
 		8CA42CC44A656C4DE5FDD444 /* BackgroundImageStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundImageStorage.swift; sourceTree = "<group>"; };
+		91427A0F32409B0DFC58A10F /* NativeAdCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeAdCard.swift; sourceTree = "<group>"; };
 		97AF12BF2EFB04266319388A /* FirebaseCrashlyticsSetupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseCrashlyticsSetupTests.swift; sourceTree = "<group>"; };
 		98F3C1F87DFC6BE33492062C /* StickerBoard.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = StickerBoard.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9B695157C87669CCB70690F4 /* StickerBoardTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = StickerBoardTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -232,6 +236,7 @@
 		A3FC7C093763688E6344217F /* StickerFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerFilter.swift; sourceTree = "<group>"; };
 		A79F18B6EE07305097CF4B9E /* PaywallView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaywallView.swift; sourceTree = "<group>"; };
 		ABCD1438794D34A642F45B93 /* StickerBorderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerBorderService.swift; sourceTree = "<group>"; };
+		AD283257FAE24DB47C1A31B0 /* AdManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdManager.swift; sourceTree = "<group>"; };
 		AFDF2A8C549FCAF35D5DD828 /* AccessibilityRuleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityRuleTests.swift; sourceTree = "<group>"; };
 		B03A91B141329E13EDBEAE9A /* StickerPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StickerPlacementTests.swift; sourceTree = "<group>"; };
 		B201CDCE2F666FBBD15D4F72 /* CaptureGuideTipsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureGuideTipsView.swift; sourceTree = "<group>"; };
@@ -283,6 +288,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				3730FADF312F90DA57192388 /* FirebaseCrashlytics in Frameworks */,
+				1D6DC7533997985BBF4CB76D /* GoogleMobileAds in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -293,6 +299,7 @@
 			isa = PBXGroup;
 			children = (
 				3834BB169411132599770224 /* HolographicEffectModifier.swift */,
+				91427A0F32409B0DFC58A10F /* NativeAdCard.swift */,
 				DF89F309D9AC84739E116281 /* StickerLibraryView.swift */,
 			);
 			path = Library;
@@ -410,6 +417,7 @@
 		9942628F63D59859340644CA /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				AD283257FAE24DB47C1A31B0 /* AdManager.swift */,
 				BCBDA121148C553378F3C860 /* AppUpdateChecker.swift */,
 				8CA42CC44A656C4DE5FDD444 /* BackgroundImageStorage.swift */,
 				E5D9FFAB2F480D8D2327E386 /* BackgroundRemover.swift */,
@@ -587,6 +595,7 @@
 			name = StickerBoard;
 			packageProductDependencies = (
 				A31113F8EC8EE2854EDFEF78 /* FirebaseCrashlytics */,
+				F10C42E0E6C50CAB03CC893B /* GoogleMobileAds */,
 			);
 			productName = StickerBoard;
 			productReference = 98F3C1F87DFC6BE33492062C /* StickerBoard.app */;
@@ -656,6 +665,7 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				71552BC30DDD3B76097B0A3C /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+				594F95C96FD81352EB4ED9F6 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 82217834547736AB42A4F71C /* Products */;
@@ -711,6 +721,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				177F476944E741FA5581B3F5 /* AdManager.swift in Sources */,
 				E2D14D4429193D3C436BA5D2 /* AppTheme.swift in Sources */,
 				08ADD0896E6540848CAB00C7 /* AppURLs.swift in Sources */,
 				25745C4F441381F490112536 /* AppUpdateChecker.swift in Sources */,
@@ -739,6 +750,7 @@
 				73FA13E3158C1F1BDACB6C08 /* MotionManager.swift in Sources */,
 				8834A7A836ECA4320FA81370 /* MultiStickerSelectionView.swift in Sources */,
 				C15AD91380FD7AF94B202969 /* MultipeerConnectivityManager.swift in Sources */,
+				C9BD7806252FFA6680B10E56 /* NativeAdCard.swift in Sources */,
 				62899C4D692BD195F7F0A16B /* OnboardingPageIndicator.swift in Sources */,
 				17F2CCB19526F58F4BCC6D04 /* OnboardingPageView.swift in Sources */,
 				EC5591236152676EACAFE16E /* OnboardingView.swift in Sources */,
@@ -1134,6 +1146,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		594F95C96FD81352EB4ED9F6 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/googleads/swift-package-manager-google-mobile-ads";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.0.0;
+			};
+		};
 		71552BC30DDD3B76097B0A3C /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
@@ -1149,6 +1169,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 71552BC30DDD3B76097B0A3C /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
 			productName = FirebaseCrashlytics;
+		};
+		F10C42E0E6C50CAB03CC893B /* GoogleMobileAds */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 594F95C96FD81352EB4ED9F6 /* XCRemoteSwiftPackageReference "swift-package-manager-google-mobile-ads" */;
+			productName = GoogleMobileAds;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/StickerBoard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/StickerBoard.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c63c63846d9c539229e96de38d6af51417e28c0ee9a0bc48bd0f0f19d923c329",
+  "originHash" : "2d3f06aab1ccdfff7b100ca10208a834bfb664b3c50890610f1e3c349eb3fbf3",
   "pins" : [
     {
       "identity" : "abseil-cpp-binary",
@@ -116,6 +116,24 @@
       "state" : {
         "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
         "version" : "2.4.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-mobile-ads",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-mobile-ads",
+      "state" : {
+        "revision" : "7778cc1ab037c10dbbe026959e51e616bd961be9",
+        "version" : "11.13.0"
+      }
+    },
+    {
+      "identity" : "swift-package-manager-google-user-messaging-platform",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/swift-package-manager-google-user-messaging-platform.git",
+      "state" : {
+        "revision" : "708a282840c2171ee63bd93b87afa49fe507d70e",
+        "version" : "2.7.0"
       }
     }
   ],

--- a/StickerBoard/App/StickerBoardApp.swift
+++ b/StickerBoard/App/StickerBoardApp.swift
@@ -46,8 +46,7 @@ struct StickerBoardApp: App {
             #endif
         }
 
-        // Google Mobile Ads SDK 初期化
-        GADMobileAds.sharedInstance().start()
+        // Google Mobile Ads SDK 初期化は ATT 許可後に AdManager.preloadAll() から呼ぶ
 
         let container: ModelContainer
         do {

--- a/StickerBoard/App/StickerBoardApp.swift
+++ b/StickerBoard/App/StickerBoardApp.swift
@@ -1,5 +1,6 @@
 import FirebaseCore
 import FirebaseCrashlytics
+import GoogleMobileAds
 import SwiftUI
 import SwiftData
 import UserNotifications
@@ -44,6 +45,9 @@ struct StickerBoardApp: App {
             Crashlytics.crashlytics().setCrashlyticsCollectionEnabled(false)
             #endif
         }
+
+        // Google Mobile Ads SDK 初期化
+        GADMobileAds.sharedInstance().start()
 
         let container: ModelContainer
         do {
@@ -92,6 +96,10 @@ struct StickerBoardApp: App {
                         hasCompletedOnboarding = true
                         Task {
                             await UnplacedStickerReminderService.shared.requestAuthorization()
+                            // オンボーディング完了後に ATT 許可を要求
+                            try? await Task.sleep(for: .seconds(1))
+                            await AdManager.shared.requestTrackingPermissionIfNeeded()
+                            AdManager.shared.preloadAll()
                         }
                     }
                 }
@@ -109,6 +117,11 @@ struct StickerBoardApp: App {
                     await UnplacedStickerReminderService.shared.rescheduleIfNeeded(
                         context: container.mainContext
                     )
+                    // 起動時にATT確認（オンボーディング済みの場合）と広告プリロード
+                    if hasCompletedOnboarding {
+                        await AdManager.shared.requestTrackingPermissionIfNeeded()
+                    }
+                    AdManager.shared.preloadAll()
                 }
         }
         .modelContainer(container)

--- a/StickerBoard/Info.plist
+++ b/StickerBoard/Info.plist
@@ -31,6 +31,8 @@
 	</array>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>GADApplicationIdentifier</key>
+	<string>ca-app-pub-3940256099942544~1458002511</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSApplicationCategoryType</key>
@@ -48,6 +50,8 @@
 	<string>ボードを画像として写真に保存するためにフォトライブラリへのアクセスが必要です</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>シールにする写真を選択するためにフォトライブラリへのアクセスが必要です</string>
+	<key>NSUserTrackingUsageDescription</key>
+	<string>広告をあなたの興味に合わせてパーソナライズするために使用します</string>
 	<key>UILaunchScreen</key>
 	<dict/>
 	<key>UISupportedInterfaceOrientations</key>

--- a/StickerBoard/InfoPlist.xcstrings
+++ b/StickerBoard/InfoPlist.xcstrings
@@ -81,6 +81,23 @@
         }
       }
     },
+    "NSUserTrackingUsageDescription" : {
+      "comment" : "Privacy - Tracking Usage Description",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This helps us show you ads that are more relevant to your interests"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "広告をあなたの興味に合わせてパーソナライズするために使用します"
+          }
+        }
+      }
+    },
     "NSPhotoLibraryUsageDescription" : {
       "comment" : "Privacy - Photo Library Usage Description",
       "localizations" : {

--- a/StickerBoard/Localizable.xcstrings
+++ b/StickerBoard/Localizable.xcstrings
@@ -812,6 +812,16 @@
         }
       }
     },
+    "このシール、まだボードに貼ってないよ📌" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This sticker hasn't been placed on a board yet 📌"
+          }
+        }
+      }
+    },
     "このシールは%lld個のボードで使用されています。削除するとボードからも取り除かれます。" : {
       "localizations" : {
         "en" : {
@@ -1373,17 +1383,6 @@
         }
       }
     },
-    "その他のアクション" : {
-      "comment" : "BoardEditorView: accessibility label for ellipsis menu (share / save)",
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "More Actions"
-          }
-        }
-      }
-    },
     "ズームをリセット" : {
       "comment" : "BoardEditorView: accessibility label for zoom reset button",
       "localizations" : {
@@ -1426,6 +1425,7 @@
       }
     },
     "すべてのシールを表示" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -1481,6 +1481,17 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Swipe to adjust background image position"
+          }
+        }
+      }
+    },
+    "その他のアクション" : {
+      "comment" : "BoardEditorView: accessibility label for ellipsis menu (share / save)",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "More Actions"
           }
         }
       }
@@ -2489,6 +2500,7 @@
       }
     },
     "先にホームからシールを追加してください" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -2521,6 +2533,7 @@
       }
     },
     "全て" : {
+      "extractionState" : "stale",
       "localizations" : {
         "en" : {
           "stringUnit" : {
@@ -3440,6 +3453,16 @@
         }
       }
     },
+    "未配置シールリマインダー" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Unplaced Sticker Reminder"
+          }
+        }
+      }
+    },
     "枠線" : {
       "localizations" : {
         "en" : {
@@ -3506,6 +3529,16 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Next"
+          }
+        }
+      }
+    },
+    "毎週土曜10時に、まだ貼っていないシールをお知らせします" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Reminds you every Saturday at 10 AM about stickers not yet placed on a board"
           }
         }
       }
@@ -4013,6 +4046,16 @@
         }
       }
     },
+    "通知" : {
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Notifications"
+          }
+        }
+      }
+    },
     "適用" : {
       "localizations" : {
         "en" : {
@@ -4119,46 +4162,6 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "Links"
-          }
-        }
-      }
-    },
-    "通知" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Notifications"
-          }
-        }
-      }
-    },
-    "未配置シールリマインダー" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Unplaced Sticker Reminder"
-          }
-        }
-      }
-    },
-    "毎週土曜10時に、まだ貼っていないシールをお知らせします" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "Reminds you every Saturday at 10 AM about stickers not yet placed on a board"
-          }
-        }
-      }
-    },
-    "このシール、まだボードに貼ってないよ📌" : {
-      "localizations" : {
-        "en" : {
-          "stringUnit" : {
-            "state" : "translated",
-            "value" : "This sticker hasn't been placed on a board yet 📌"
           }
         }
       }

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -127,7 +127,7 @@ final class AdManager {
 
 private extension AdManager {
     enum AdUnitID {
-        static let interstitial = "ca-app-pub-3940256099942544/4411468910"  // TODO: 本番インタースティシャルIDに差し替えること
+        static let interstitial = "ca-app-pub-6267199278067658/5226451726"
         static let native = "ca-app-pub-6267199278067658/3000803125"
     }
 }

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -127,9 +127,8 @@ final class AdManager {
 
 private extension AdManager {
     enum AdUnitID {
-        // TODO: App Store 提出前に AdMob コンソールの本番 ID に差し替えること
-        static let interstitial = "ca-app-pub-3940256099942544/4411468910"
-        static let native = "ca-app-pub-3940256099942544/3986624511"
+        static let interstitial = "ca-app-pub-3940256099942544/4411468910"  // TODO: 本番インタースティシャルIDに差し替えること
+        static let native = "ca-app-pub-6267199278067658/3000803125"
     }
 }
 

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -33,9 +33,14 @@ final class AdManager {
         interstitialDelegate = AdInterstitialDelegate { [weak self] in
             self?.preloadInterstitial()
         }
-        nativeAdDelegate = AdNativeDelegate { [weak self] ad in
-            self?.nativeAd = ad
-        }
+        nativeAdDelegate = AdNativeDelegate(
+            onReceive: { [weak self] ad in
+                self?.nativeAd = ad
+            },
+            onError: { [weak self] error in
+                self?.logger.error("Native ad load failed: \(error)")
+            }
+        )
     }
 
     // MARK: - Public API
@@ -134,11 +139,18 @@ private final class AdInterstitialDelegate: NSObject, GADFullScreenContentDelega
 
 private final class AdNativeDelegate: NSObject, GADNativeAdLoaderDelegate, @unchecked Sendable {
     private let onReceive: (GADNativeAd) -> Void
-    init(onReceive: @escaping (GADNativeAd) -> Void) { self.onReceive = onReceive }
+    private let onError: (Error) -> Void
+
+    init(onReceive: @escaping (GADNativeAd) -> Void, onError: @escaping (Error) -> Void) {
+        self.onReceive = onReceive
+        self.onError = onError
+    }
 
     func adLoader(_ adLoader: GADAdLoader, didReceive nativeAd: GADNativeAd) {
         Task { @MainActor in self.onReceive(nativeAd) }
     }
 
-    func adLoader(_ adLoader: GADAdLoader, didFailToReceiveAdWithError error: Error) {}
+    func adLoader(_ adLoader: GADAdLoader, didFailToReceiveAdWithError error: Error) {
+        Task { @MainActor in self.onError(error) }
+    }
 }

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -47,7 +47,12 @@ final class AdManager {
     // MARK: - Public API
 
     func preloadAll() {
-        guard !SubscriptionManager.shared.isProUser else { return }
+        let isPro = SubscriptionManager.shared.isProUser
+        logger.info("preloadAll: called, isProUser=\(isPro)")
+        guard !isPro else {
+            logger.info("preloadAll: skipped (Pro user)")
+            return
+        }
         // ATT 許可が確定してから SDK を初期化することで IDFA を適切に取得する
         GADMobileAds.sharedInstance().start()
         preloadInterstitial()

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -42,6 +42,8 @@ final class AdManager {
 
     func preloadAll() {
         guard !SubscriptionManager.shared.isProUser else { return }
+        // ATT 許可が確定してから SDK を初期化することで IDFA を適切に取得する
+        GADMobileAds.sharedInstance().start()
         preloadInterstitial()
         preloadNativeAd()
     }

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -35,6 +35,7 @@ final class AdManager {
         }
         nativeAdDelegate = AdNativeDelegate(
             onReceive: { [weak self] ad in
+                self?.logger.info("Native ad received: \(ad.headline ?? "-")")
                 self?.nativeAd = ad
             },
             onError: { [weak self] error in
@@ -91,6 +92,7 @@ final class AdManager {
 
     func preloadNativeAd() {
         guard !SubscriptionManager.shared.isProUser else { return }
+        logger.info("preloadNativeAd called")
         adLoader = GADAdLoader(
             adUnitID: AdUnitID.native,
             rootViewController: nil,

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -102,7 +102,7 @@ final class AdManager {
         guard let ad = interstitialAd,
               let scene = UIApplication.shared.connectedScenes
                   .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
-              let rootVC = scene.windows.first(where: \.isKeyWindow)?.rootViewController
+              let rootVC = scene.keyWindow?.rootViewController
         else { return }
         var topVC = rootVC
         while let presented = topVC.presentedViewController { topVC = presented }

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -35,7 +35,6 @@ final class AdManager {
         }
         nativeAdDelegate = AdNativeDelegate(
             onReceive: { [weak self] ad in
-                self?.logger.info("Native ad received: \(ad.headline ?? "-")")
                 self?.nativeAd = ad
             },
             onError: { [weak self] error in
@@ -47,12 +46,7 @@ final class AdManager {
     // MARK: - Public API
 
     func preloadAll() {
-        let isPro = SubscriptionManager.shared.isProUser
-        logger.info("preloadAll: called, isProUser=\(isPro)")
-        guard !isPro else {
-            logger.info("preloadAll: skipped (Pro user)")
-            return
-        }
+        guard !SubscriptionManager.shared.isProUser else { return }
         // ATT 許可が確定してから SDK を初期化することで IDFA を適切に取得する
         GADMobileAds.sharedInstance().start()
         preloadInterstitial()
@@ -97,7 +91,6 @@ final class AdManager {
 
     func preloadNativeAd() {
         guard !SubscriptionManager.shared.isProUser else { return }
-        logger.info("preloadNativeAd called")
         adLoader = GADAdLoader(
             adUnitID: AdUnitID.native,
             rootViewController: nil,

--- a/StickerBoard/Services/AdManager.swift
+++ b/StickerBoard/Services/AdManager.swift
@@ -1,0 +1,142 @@
+import AppTrackingTransparency
+import GoogleMobileAds
+import OSLog
+import UIKit
+
+// MARK: - AdManager
+
+/// 広告表示を一元管理するシングルトン。Pro ユーザーには一切広告を表示しない。
+@Observable
+@MainActor
+final class AdManager {
+    static let shared: AdManager = {
+        let manager = AdManager()
+        manager.setupDelegates()
+        return manager
+    }()
+
+    /// グリッドに挿入するネイティブ広告（ロード完了後に非 nil になる）
+    private(set) var nativeAd: GADNativeAd?
+
+    @ObservationIgnored private var interstitialAd: GADInterstitialAd?
+    @ObservationIgnored private var adLoader: GADAdLoader?
+    @ObservationIgnored private var exportActionCount = 0
+    @ObservationIgnored private var interstitialDelegate: AdInterstitialDelegate!
+    @ObservationIgnored private var nativeAdDelegate: AdNativeDelegate!
+
+    private static let showInterval = 3
+    private let logger = Logger(subsystem: "com.tebasaki.StickerBoard", category: "AdManager")
+
+    private init() {}
+
+    private func setupDelegates() {
+        interstitialDelegate = AdInterstitialDelegate { [weak self] in
+            self?.preloadInterstitial()
+        }
+        nativeAdDelegate = AdNativeDelegate { [weak self] ad in
+            self?.nativeAd = ad
+        }
+    }
+
+    // MARK: - Public API
+
+    func preloadAll() {
+        guard !SubscriptionManager.shared.isProUser else { return }
+        preloadInterstitial()
+        preloadNativeAd()
+    }
+
+    /// ATT 許可ダイアログを初回のみ表示する（オンボーディング完了後に呼ぶ）
+    func requestTrackingPermissionIfNeeded() async {
+        let key = "hasRequestedATT"
+        guard !UserDefaults.standard.bool(forKey: key) else { return }
+        UserDefaults.standard.set(true, forKey: key)
+        _ = await ATTrackingManager.requestTrackingAuthorization()
+    }
+
+    /// エクスポート or 写真保存が 1 回完了するたびに呼ぶ。
+    /// 累計 showInterval 回ごとにインタースティシャルを表示する。
+    func recordExportAndShowIfNeeded() {
+        guard !SubscriptionManager.shared.isProUser else { return }
+        exportActionCount += 1
+        guard exportActionCount % Self.showInterval == 0 else { return }
+        showInterstitial()
+    }
+
+    // MARK: - Preload
+
+    func preloadInterstitial() {
+        guard !SubscriptionManager.shared.isProUser else { return }
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            do {
+                let ad = try await GADInterstitialAd.load(
+                    withAdUnitID: AdUnitID.interstitial,
+                    request: GADRequest()
+                )
+                ad.fullScreenContentDelegate = self.interstitialDelegate
+                self.interstitialAd = ad
+            } catch {
+                self.logger.error("Interstitial load failed: \(error)")
+            }
+        }
+    }
+
+    func preloadNativeAd() {
+        guard !SubscriptionManager.shared.isProUser else { return }
+        adLoader = GADAdLoader(
+            adUnitID: AdUnitID.native,
+            rootViewController: nil,
+            adTypes: [.native],
+            options: nil
+        )
+        adLoader?.delegate = nativeAdDelegate
+        adLoader?.load(GADRequest())
+    }
+
+    // MARK: - Private
+
+    private func showInterstitial() {
+        guard let ad = interstitialAd,
+              let scene = UIApplication.shared.connectedScenes
+                  .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene,
+              let rootVC = scene.windows.first(where: \.isKeyWindow)?.rootViewController
+        else { return }
+        var topVC = rootVC
+        while let presented = topVC.presentedViewController { topVC = presented }
+        ad.present(fromRootViewController: topVC)
+        interstitialAd = nil
+    }
+}
+
+// MARK: - Ad Unit IDs
+
+private extension AdManager {
+    enum AdUnitID {
+        // TODO: App Store 提出前に AdMob コンソールの本番 ID に差し替えること
+        static let interstitial = "ca-app-pub-3940256099942544/4411468910"
+        static let native = "ca-app-pub-3940256099942544/3986624511"
+    }
+}
+
+// MARK: - Delegate Helpers
+
+private final class AdInterstitialDelegate: NSObject, GADFullScreenContentDelegate, @unchecked Sendable {
+    private let onDismiss: () -> Void
+    init(onDismiss: @escaping () -> Void) { self.onDismiss = onDismiss }
+
+    func adDidDismissFullScreenContent(_ ad: GADFullScreenPresentingAd) {
+        Task { @MainActor in self.onDismiss() }
+    }
+}
+
+private final class AdNativeDelegate: NSObject, GADNativeAdLoaderDelegate, @unchecked Sendable {
+    private let onReceive: (GADNativeAd) -> Void
+    init(onReceive: @escaping (GADNativeAd) -> Void) { self.onReceive = onReceive }
+
+    func adLoader(_ adLoader: GADAdLoader, didReceive nativeAd: GADNativeAd) {
+        Task { @MainActor in self.onReceive(nativeAd) }
+    }
+
+    func adLoader(_ adLoader: GADAdLoader, didFailToReceiveAdWithError error: Error) {}
+}

--- a/StickerBoard/Services/BoardShareService.swift
+++ b/StickerBoard/Services/BoardShareService.swift
@@ -82,6 +82,11 @@ enum BoardShareService {
             popover.permittedArrowDirections = []
         }
 
+        // 共有完了後にインタースティシャル広告を表示（#260）
+        activityVC.completionWithItemsHandler = { _, completed, _, _ in
+            guard completed else { return }
+            Task { @MainActor in AdManager.shared.recordExportAndShowIfNeeded() }
+        }
         topVC.present(activityVC, animated: true)
     }
 

--- a/StickerBoard/Views/Board/BoardEditorView.swift
+++ b/StickerBoard/Views/Board/BoardEditorView.swift
@@ -267,6 +267,11 @@ struct BoardEditorView: View {
                  ? "ボードを写真に保存しました"
                  : "写真の保存に失敗しました。設定から写真へのアクセスを許可してください。")
         }
+        // 写真保存アラートが閉じた後にインタースティシャル広告を表示（#260）
+        .onChange(of: showingSaveResult) { oldValue, newValue in
+            guard oldValue, !newValue, saveResultSuccess else { return }
+            AdManager.shared.recordExportAndShowIfNeeded()
+        }
         .onAppear {
             placements = board.placements
             backgroundConfig = board.backgroundPattern

--- a/StickerBoard/Views/Library/NativeAdCard.swift
+++ b/StickerBoard/Views/Library/NativeAdCard.swift
@@ -1,0 +1,140 @@
+import GoogleMobileAds
+import SwiftUI
+
+// MARK: - NativeAdCard
+
+/// グリッドに挿入するネイティブ広告カード。
+/// AdManager.shared.nativeAd が nil のときは非表示になる（グリッドが詰まる）。
+struct NativeAdCard: View {
+    var body: some View {
+        if let nativeAd = AdManager.shared.nativeAd {
+            NativeAdViewRepresentable(nativeAd: nativeAd)
+                .frame(maxWidth: .infinity)
+                .frame(height: 76)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+                .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 2)
+                .accessibilityLabel("広告")
+                .accessibilityAddTraits(.isStaticText)
+        }
+    }
+}
+
+// MARK: - UIViewRepresentable
+
+private struct NativeAdViewRepresentable: UIViewRepresentable {
+    let nativeAd: GADNativeAd
+
+    func makeUIView(context: Context) -> NativeAdDisplayView {
+        NativeAdDisplayView()
+    }
+
+    func updateUIView(_ uiView: NativeAdDisplayView, context: Context) {
+        uiView.populate(with: nativeAd)
+    }
+}
+
+// MARK: - NativeAdDisplayView
+
+private final class NativeAdDisplayView: GADNativeAdView {
+    // MARK: Ad asset subviews
+
+    private let adBadgeLabel: UILabel = {
+        let label = UILabel()
+        label.text = "広告"
+        label.font = .systemFont(ofSize: 10)
+        label.textColor = UIColor(red: 160/255, green: 162/255, blue: 184/255, alpha: 1) // textTertiary
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let iconImageView: UIImageView = {
+        let iv = UIImageView()
+        iv.contentMode = .scaleAspectFit
+        iv.layer.cornerRadius = 8
+        iv.clipsToBounds = true
+        iv.translatesAutoresizingMaskIntoConstraints = false
+        return iv
+    }()
+
+    private let headlineLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 13, weight: .semibold)
+        label.textColor = UIColor(red: 42/255, green: 45/255, blue: 91/255, alpha: 1) // textPrimary
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let bodyLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 11)
+        label.textColor = UIColor(red: 107/255, green: 109/255, blue: 142/255, alpha: 1) // textSecondary
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    private let ctaLabel: UILabel = {
+        let label = UILabel()
+        label.font = .systemFont(ofSize: 12, weight: .bold)
+        label.textColor = UIColor(red: 232/255, green: 122/255, blue: 46/255, alpha: 1) // accent
+        label.numberOfLines = 1
+        label.translatesAutoresizingMaskIntoConstraints = false
+        return label
+    }()
+
+    // MARK: Init
+
+    init() {
+        super.init(frame: .zero)
+        backgroundColor = UIColor(red: 1, green: 254/255, blue: 248/255, alpha: 1) // backgroundCard
+        setupLayout()
+        // GADNativeAdView の登録済みビューとして設定
+        headlineView = headlineLabel
+        bodyView = bodyLabel
+        iconView = iconImageView
+        callToActionView = ctaLabel
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    // MARK: Layout
+
+    private func setupLayout() {
+        let textStack = UIStackView(arrangedSubviews: [headlineLabel, bodyLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+        textStack.alignment = .leading
+        textStack.translatesAutoresizingMaskIntoConstraints = false
+
+        [adBadgeLabel, iconImageView, textStack, ctaLabel].forEach { addSubview($0) }
+
+        NSLayoutConstraint.activate([
+            adBadgeLabel.topAnchor.constraint(equalTo: topAnchor, constant: 6),
+            adBadgeLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+
+            iconImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
+            iconImageView.topAnchor.constraint(equalTo: adBadgeLabel.bottomAnchor, constant: 4),
+            iconImageView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor, constant: -8),
+            iconImageView.widthAnchor.constraint(equalToConstant: 36),
+            iconImageView.heightAnchor.constraint(equalToConstant: 36),
+
+            textStack.leadingAnchor.constraint(equalTo: iconImageView.trailingAnchor, constant: 10),
+            textStack.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+            textStack.trailingAnchor.constraint(lessThanOrEqualTo: ctaLabel.leadingAnchor, constant: -8),
+
+            ctaLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -12),
+            ctaLabel.centerYAnchor.constraint(equalTo: iconImageView.centerYAnchor),
+        ])
+    }
+
+    // MARK: Populate
+
+    func populate(with ad: GADNativeAd) {
+        headlineLabel.text = ad.headline
+        bodyLabel.text = ad.body
+        ctaLabel.text = ad.callToAction
+        iconImageView.image = ad.icon?.image
+        nativeAd = ad
+    }
+}

--- a/StickerBoard/Views/Library/NativeAdCard.swift
+++ b/StickerBoard/Views/Library/NativeAdCard.swift
@@ -4,18 +4,20 @@ import SwiftUI
 // MARK: - NativeAdCard
 
 /// グリッドに挿入するネイティブ広告カード。
-/// AdManager.shared.nativeAd が nil のときは非表示になる（グリッドが詰まる）。
+/// nativeAd は呼び出し元（StickerLibraryView）から渡す。
+/// @Observable singleton を直接参照すると SwiftUI の再レンダリングが発火しないため、
+/// 呼び出し元で @State として保持した adManager.nativeAd を引数経由で受け取る設計。
 struct NativeAdCard: View {
+    let nativeAd: GADNativeAd
+
     var body: some View {
-        if let nativeAd = AdManager.shared.nativeAd {
-            NativeAdViewRepresentable(nativeAd: nativeAd)
-                .frame(maxWidth: .infinity)
-                .frame(height: 76)
-                .clipShape(RoundedRectangle(cornerRadius: 16))
-                .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 2)
-                .accessibilityLabel("広告")
-                .accessibilityAddTraits(.isStaticText)
-        }
+        NativeAdViewRepresentable(nativeAd: nativeAd)
+            .frame(maxWidth: .infinity)
+            .frame(height: 76)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .shadow(color: .black.opacity(0.06), radius: 8, x: 0, y: 2)
+            .accessibilityLabel("広告")
+            .accessibilityAddTraits(.isStaticText)
     }
 }
 

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -11,6 +11,8 @@ struct StickerLibraryView: View {
     @Environment(\.dismiss) private var dismiss
     @Query private var boards: [Board]
     @ObservedObject private var subscriptionManager = SubscriptionManager.shared
+    // @Observable singleton は @State で保持することで変更時の再レンダリングを保証する
+    @State private var adManager = AdManager.shared
     @State private var displayedStickers: [Sticker] = []
     @State private var totalCount: Int = 0
     @State private var hasMorePages = true
@@ -283,9 +285,10 @@ struct StickerLibraryView: View {
                     }
                     .padding(.top, chunkIndex > 0 ? 14 : 0)
 
-                    // 最初の 12 枚チャンクの後のみ広告を表示（同一広告の重複インプレッション防止）
-                    if showAds && chunk.count == adPerChunk && chunkIndex == 0 {
-                        NativeAdCard().padding(.top, 14)
+                    // 最初のチャンク後のみ広告を表示（同一広告の重複インプレッション防止）
+                    // adManager を @State で保持することで nativeAd 変更時に自動再レンダリング
+                    if showAds, chunkIndex == 0, let nativeAd = adManager.nativeAd {
+                        NativeAdCard(nativeAd: nativeAd).padding(.top, 14)
                     }
                 }
             }

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -93,6 +93,11 @@ struct StickerLibraryView: View {
                     Text("フォトライブラリへの保存中にエラーが発生しました。アクセス許可を確認してください。")
                 }
             }
+            // 写真保存アラートが閉じた後にインタースティシャル広告を表示（#261）
+            .onChange(of: showSaveToPhotosResult) { oldValue, newValue in
+                guard oldValue, !newValue, saveToPhotosSuccess else { return }
+                AdManager.shared.recordExportAndShowIfNeeded()
+            }
     }
 
     private var libraryContent: some View {
@@ -254,6 +259,38 @@ struct StickerLibraryView: View {
 
     // MARK: - グリッド
 
+    /// ネイティブ広告を 12 枚ごとに挿入したグリッドコンテンツ。
+    /// ピッカーモード・Pro ユーザーでは広告を非表示。ロード失敗時もレイアウト崩れなし。
+    @ViewBuilder
+    private var stickerGridContent: some View {
+        if displayedStickers.isEmpty {
+            LazyVGrid(columns: columns, spacing: 14) {
+                if !isPicking { addStickerCard }
+            }
+        } else {
+            let adPerChunk = 12
+            let chunks: [[Sticker]] = stride(from: 0, to: displayedStickers.count, by: adPerChunk).map {
+                Array(displayedStickers[$0..<min($0 + adPerChunk, displayedStickers.count)])
+            }
+            let showAds = !isPicking && !SubscriptionManager.shared.isProUser
+
+            LazyVStack(spacing: 0) {
+                ForEach(Array(chunks.enumerated()), id: \.offset) { chunkIndex, chunk in
+                    LazyVGrid(columns: columns, spacing: 14) {
+                        if chunkIndex == 0 && !isPicking { addStickerCard }
+                        ForEach(chunk) { sticker in stickerCell(for: sticker) }
+                    }
+                    .padding(.top, chunkIndex > 0 ? 14 : 0)
+
+                    // 12 枚ちょうどのチャンクの後のみ広告を表示（最後の不完全チャンクには出さない）
+                    if showAds && chunk.count == adPerChunk {
+                        NativeAdCard().padding(.top, 14)
+                    }
+                }
+            }
+        }
+    }
+
     private var stickerGrid: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 12) {
@@ -273,15 +310,7 @@ struct StickerLibraryView: View {
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel("全\(totalCount)枚のシール")
 
-                LazyVGrid(columns: columns, spacing: 14) {
-                    if !isPicking {
-                        addStickerCard
-                    }
-
-                    ForEach(displayedStickers) { sticker in
-                        stickerCell(for: sticker)
-                    }
-                }
+                stickerGridContent
 
                 if hasMorePages && !displayedStickers.isEmpty {
                     HStack {

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -276,6 +276,9 @@ struct StickerLibraryView: View {
                 Array(displayedStickers[$0..<min($0 + adPerChunk, displayedStickers.count)])
             }
             let showAds = !isPicking && !subscriptionManager.isProUser
+            // LazyVStack/ForEach 内の closure では @Observable の変更が SwiftUI に伝播しない場合があるため、
+            // LazyVStack の外側（@ViewBuilder の評価時）で adManager.nativeAd を参照してオブザベーションを登録する
+            let loadedNativeAd = adManager.nativeAd
 
             LazyVStack(spacing: 0) {
                 ForEach(Array(chunks.enumerated()), id: \.offset) { chunkIndex, chunk in
@@ -286,8 +289,7 @@ struct StickerLibraryView: View {
                     .padding(.top, chunkIndex > 0 ? 14 : 0)
 
                     // 最初のチャンク後のみ広告を表示（同一広告の重複インプレッション防止）
-                    // adManager を @State で保持することで nativeAd 変更時に自動再レンダリング
-                    if showAds, chunkIndex == 0, let nativeAd = adManager.nativeAd {
+                    if showAds, chunkIndex == 0, let nativeAd = loadedNativeAd {
                         NativeAdCard(nativeAd: nativeAd).padding(.top, 14)
                     }
                 }

--- a/StickerBoard/Views/Library/StickerLibraryView.swift
+++ b/StickerBoard/Views/Library/StickerLibraryView.swift
@@ -10,6 +10,7 @@ struct StickerLibraryView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.dismiss) private var dismiss
     @Query private var boards: [Board]
+    @ObservedObject private var subscriptionManager = SubscriptionManager.shared
     @State private var displayedStickers: [Sticker] = []
     @State private var totalCount: Int = 0
     @State private var hasMorePages = true
@@ -272,7 +273,7 @@ struct StickerLibraryView: View {
             let chunks: [[Sticker]] = stride(from: 0, to: displayedStickers.count, by: adPerChunk).map {
                 Array(displayedStickers[$0..<min($0 + adPerChunk, displayedStickers.count)])
             }
-            let showAds = !isPicking && !SubscriptionManager.shared.isProUser
+            let showAds = !isPicking && !subscriptionManager.isProUser
 
             LazyVStack(spacing: 0) {
                 ForEach(Array(chunks.enumerated()), id: \.offset) { chunkIndex, chunk in
@@ -282,8 +283,8 @@ struct StickerLibraryView: View {
                     }
                     .padding(.top, chunkIndex > 0 ? 14 : 0)
 
-                    // 12 枚ちょうどのチャンクの後のみ広告を表示（最後の不完全チャンクには出さない）
-                    if showAds && chunk.count == adPerChunk {
+                    // 最初の 12 枚チャンクの後のみ広告を表示（同一広告の重複インプレッション防止）
+                    if showAds && chunk.count == adPerChunk && chunkIndex == 0 {
                         NativeAdCard().padding(.top, 14)
                     }
                 }

--- a/app.pen
+++ b/app.pen
@@ -1,0 +1,4059 @@
+{
+  "version": "2.11",
+  "children": [
+    {
+      "type": "frame",
+      "id": "TsxL0",
+      "x": 0,
+      "y": 0,
+      "name": "ホームタブ",
+      "clip": true,
+      "width": 393,
+      "height": 852,
+      "fill": "#FAF0DE",
+      "layout": "none",
+      "children": [
+        {
+          "type": "frame",
+          "id": "L353u",
+          "x": 0,
+          "y": 0,
+          "name": "NavBar",
+          "width": 393,
+          "height": 96,
+          "fill": "#FAF0DE",
+          "layout": "none"
+        },
+        {
+          "type": "text",
+          "id": "Z6qw4x",
+          "x": 136,
+          "y": 56,
+          "name": "NavTitle",
+          "fill": "#E87A2E",
+          "content": "シールボード",
+          "fontFamily": "Inter",
+          "fontSize": 20,
+          "fontWeight": "900"
+        },
+        {
+          "type": "frame",
+          "id": "POSHM",
+          "x": 16,
+          "y": 48,
+          "name": "GearBtn",
+          "width": 36,
+          "height": 36,
+          "layout": "none",
+          "children": [
+            {
+              "type": "text",
+              "id": "KLAl5",
+              "x": 8,
+              "y": 7,
+              "name": "homeGearIcon",
+              "fill": "#6B6D8E",
+              "content": "⚙",
+              "fontFamily": "Inter",
+              "fontSize": 20,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "rN9ld",
+          "x": 341,
+          "y": 48,
+          "name": "HelpBtn",
+          "width": 36,
+          "height": 36,
+          "layout": "none",
+          "children": [
+            {
+              "type": "text",
+              "id": "T726VD",
+              "x": 12,
+              "y": 7,
+              "name": "homeHelpIcon",
+              "fill": "#6B6D8E",
+              "content": "?",
+              "fontFamily": "Inter",
+              "fontSize": 18,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "id": "phUkZ",
+          "x": 0,
+          "y": 95,
+          "name": "NavDivider",
+          "fill": "#E5DDD0",
+          "width": 393,
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "ToWnZ",
+          "x": 24,
+          "y": 108,
+          "name": "BoardCard1",
+          "clip": true,
+          "width": 345,
+          "height": 570,
+          "cornerRadius": 28,
+          "layout": "none",
+          "children": [
+            {
+              "type": "rectangle",
+              "id": "zk6l9",
+              "x": 0,
+              "y": 0,
+              "name": "CardBg",
+              "fill": "#E8E0D5",
+              "width": 345,
+              "height": 570
+            },
+            {
+              "type": "ellipse",
+              "id": "HeokK",
+              "x": 60,
+              "y": 80,
+              "name": "StickerMock1",
+              "opacity": 0.8,
+              "fill": "#E87A2E",
+              "width": 110,
+              "height": 110
+            },
+            {
+              "type": "ellipse",
+              "id": "dJS6j",
+              "x": 200,
+              "y": 140,
+              "name": "StickerMock2",
+              "opacity": 0.7,
+              "fill": "#2A2D5B",
+              "width": 85,
+              "height": 85
+            },
+            {
+              "type": "ellipse",
+              "id": "diqnu",
+              "x": 130,
+              "y": 260,
+              "name": "StickerMock3",
+              "opacity": 0.9,
+              "fill": "#F0A870",
+              "width": 70,
+              "height": 70
+            },
+            {
+              "type": "rectangle",
+              "id": "J4H50K",
+              "x": 0,
+              "y": 430,
+              "name": "BottomGrad",
+              "fill": {
+                "type": "gradient",
+                "gradientType": "linear",
+                "enabled": true,
+                "rotation": 180,
+                "size": {
+                  "height": 1
+                },
+                "colors": [
+                  {
+                    "color": "#00000000",
+                    "position": 0
+                  },
+                  {
+                    "color": "#00000073",
+                    "position": 1
+                  }
+                ]
+              },
+              "width": 345,
+              "height": 140
+            },
+            {
+              "type": "text",
+              "id": "HdKrQ",
+              "x": 16,
+              "y": 452,
+              "name": "BoardTitle",
+              "fill": "#FFFFFF",
+              "content": "夏のシール集め",
+              "fontFamily": "Inter",
+              "fontSize": 22,
+              "fontWeight": "900"
+            },
+            {
+              "type": "text",
+              "id": "l4nWAR",
+              "x": 16,
+              "y": 478,
+              "name": "StickerCount",
+              "fill": "#FFFFFFCC",
+              "content": "3枚",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "600"
+            },
+            {
+              "type": "ellipse",
+              "id": "dToaQ",
+              "x": 295,
+              "y": 524,
+              "name": "MenuBtn",
+              "fill": "#FFFFFF26",
+              "width": 34,
+              "height": 34
+            },
+            {
+              "type": "text",
+              "id": "erFTA",
+              "x": 299,
+              "y": 533,
+              "name": "MenuDots",
+              "fill": "#FFFFFFEE",
+              "content": "•••",
+              "fontFamily": "Inter",
+              "fontSize": 10,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "OabtN",
+          "x": 161,
+          "y": 694,
+          "name": "PageIndicators",
+          "width": 71,
+          "height": 8,
+          "gap": 6,
+          "children": [
+            {
+              "type": "rectangle",
+              "cornerRadius": 4,
+              "id": "V5M31l",
+              "name": "dot1",
+              "fill": "#E87A2E",
+              "width": 24,
+              "height": 8
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 4,
+              "id": "gCPJU",
+              "name": "dot2",
+              "fill": "#E87A2E33",
+              "width": 8,
+              "height": 8
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 4,
+              "id": "D9wsQ",
+              "name": "dot3",
+              "fill": "#E87A2E33",
+              "width": 8,
+              "height": 8
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 32,
+          "id": "yFzDZ",
+          "x": 32,
+          "y": 766,
+          "name": "TabBarBg",
+          "fill": "#EAEAEA",
+          "width": 329,
+          "height": 64,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": -4
+            },
+            "blur": 24
+          }
+        },
+        {
+          "type": "ellipse",
+          "id": "QeDT4",
+          "x": 56,
+          "y": 775,
+          "name": "HomeTabActive",
+          "fill": "#E87A2E",
+          "width": 46,
+          "height": 46
+        },
+        {
+          "type": "icon_font",
+          "id": "IChlp",
+          "x": 68,
+          "y": 787,
+          "name": "HomeIcon",
+          "width": 22,
+          "height": 22,
+          "iconFontName": "grid-2x2",
+          "iconFontFamily": "lucide",
+          "fill": "#FFFFFF"
+        },
+        {
+          "type": "ellipse",
+          "id": "o9ioIC",
+          "x": 168,
+          "y": 747,
+          "name": "CaptureBtn",
+          "fill": "#E87A2E",
+          "width": 56,
+          "height": 56,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#E87A2E66",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 10
+          }
+        },
+        {
+          "type": "icon_font",
+          "id": "f9dmV",
+          "x": 184,
+          "y": 762,
+          "name": "PlusIcon",
+          "width": 26,
+          "height": 26,
+          "iconFontName": "plus",
+          "iconFontFamily": "lucide",
+          "fill": "#FFFFFF"
+        },
+        {
+          "type": "icon_font",
+          "id": "eUEqt",
+          "x": 288,
+          "y": 787,
+          "name": "LibraryIcon",
+          "width": 22,
+          "height": 22,
+          "iconFontName": "star",
+          "iconFontFamily": "lucide",
+          "fill": "#6B6D8E"
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "h9DO5",
+      "x": 430,
+      "y": 0,
+      "name": "ライブラリタブ",
+      "clip": true,
+      "width": 393,
+      "height": 852,
+      "fill": "#FAF0DE",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "WRy6l",
+          "x": 0,
+          "y": 0,
+          "name": "LibNavBg",
+          "fill": "#FAF0DE",
+          "width": 393,
+          "height": 96
+        },
+        {
+          "type": "text",
+          "id": "qjD3U",
+          "x": 165,
+          "y": 58,
+          "name": "LibNavTitle",
+          "fill": "#2A2D5B",
+          "content": "ライブラリ",
+          "fontFamily": "Inter",
+          "fontSize": 17,
+          "fontWeight": "700"
+        },
+        {
+          "type": "icon_font",
+          "id": "Y3Pad",
+          "x": 353,
+          "y": 56,
+          "name": "SortIcon",
+          "width": 20,
+          "height": 20,
+          "iconFontName": "arrow-up-down",
+          "iconFontFamily": "lucide",
+          "fill": "#6B6D8E"
+        },
+        {
+          "type": "rectangle",
+          "id": "oyDQb",
+          "x": 0,
+          "y": 95,
+          "name": "libDivider",
+          "fill": "#E5DDD0",
+          "width": 393,
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "o7rfTQ",
+          "x": 20,
+          "y": 112,
+          "name": "CountBadge",
+          "width": 64,
+          "height": 24,
+          "fill": "#E87A2E1A",
+          "cornerRadius": 12,
+          "gap": 4,
+          "children": [
+            {
+              "type": "icon_font",
+              "id": "pbgS4",
+              "name": "libCountStar",
+              "width": 12,
+              "height": 12,
+              "iconFontName": "star",
+              "iconFontFamily": "lucide",
+              "fill": "#E87A2E"
+            },
+            {
+              "type": "text",
+              "id": "EOdf5",
+              "name": "libCountText",
+              "fill": "#E87A2E",
+              "content": "12枚",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "jxIJV",
+          "x": 20,
+          "y": 148,
+          "name": "AddCard",
+          "width": 100,
+          "height": 100,
+          "fill": "#E87A2E0A",
+          "cornerRadius": 14,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#E87A2E66"
+          },
+          "layout": "vertical",
+          "gap": 8,
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "gZaPO",
+              "name": "addCircle",
+              "fill": "#E87A2E1F",
+              "width": 44,
+              "height": 44
+            },
+            {
+              "type": "icon_font",
+              "id": "MEAP9",
+              "name": "addPlusIcon",
+              "width": 22,
+              "height": 22,
+              "iconFontName": "plus",
+              "iconFontFamily": "lucide",
+              "fill": "#E87A2E"
+            },
+            {
+              "type": "text",
+              "id": "dlzHb",
+              "name": "addLabel",
+              "fill": "#E87A2E",
+              "content": "さらに追加",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "600"
+            }
+          ]
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "C5uLXI",
+          "x": 134,
+          "y": 148,
+          "name": "SC1",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "H5EXIx",
+          "x": 252,
+          "y": 148,
+          "name": "SC2",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "lb0Gd",
+          "x": 20,
+          "y": 276,
+          "name": "SC3",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "sNkTg",
+          "x": 134,
+          "y": 276,
+          "name": "SC4",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "oNAYK",
+          "x": 252,
+          "y": 276,
+          "name": "SC5",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "TXwj0",
+          "x": 20,
+          "y": 404,
+          "name": "SC6",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "mlgdd",
+          "x": 134,
+          "y": 404,
+          "name": "SC7",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 14,
+          "id": "I1JVm",
+          "x": 252,
+          "y": 404,
+          "name": "SC8",
+          "fill": "#FFFEF8",
+          "width": 100,
+          "height": 100,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 3
+            },
+            "blur": 6
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 32,
+          "id": "yAvPV",
+          "x": 32,
+          "y": 766,
+          "name": "TabBarBg",
+          "fill": "#EAEAEA",
+          "width": 329,
+          "height": 64,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#00000014",
+            "offset": {
+              "x": 0,
+              "y": -4
+            },
+            "blur": 24
+          }
+        },
+        {
+          "type": "icon_font",
+          "id": "s1HY4g",
+          "x": 81,
+          "y": 787,
+          "name": "libHomeIcon",
+          "width": 22,
+          "height": 22,
+          "iconFontName": "grid-2x2",
+          "iconFontFamily": "lucide",
+          "fill": "#6B6D8E"
+        },
+        {
+          "type": "ellipse",
+          "id": "yXyId",
+          "x": 168,
+          "y": 747,
+          "name": "CaptureBtn",
+          "fill": "#E87A2E",
+          "width": 56,
+          "height": 56,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#E87A2E66",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 10
+          }
+        },
+        {
+          "type": "icon_font",
+          "id": "IERik",
+          "x": 184,
+          "y": 762,
+          "name": "libCapturePlusIcon",
+          "width": 26,
+          "height": 26,
+          "iconFontName": "plus",
+          "iconFontFamily": "lucide",
+          "fill": "#FFFFFF"
+        },
+        {
+          "type": "ellipse",
+          "id": "QVxE2",
+          "x": 272,
+          "y": 775,
+          "name": "LibActiveTab",
+          "fill": "#E87A2E",
+          "width": 46,
+          "height": 46
+        },
+        {
+          "type": "icon_font",
+          "id": "d0hywf",
+          "x": 284,
+          "y": 787,
+          "name": "libActiveIcon",
+          "width": 22,
+          "height": 22,
+          "iconFontName": "star",
+          "iconFontFamily": "lucide",
+          "fill": "#FFFFFF"
+        },
+        {
+          "type": "ellipse",
+          "id": "AADcM",
+          "x": 152,
+          "y": 166,
+          "name": "S1Inner",
+          "opacity": 0.85,
+          "fill": "#E87A2E",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "ellipse",
+          "id": "wOOeu",
+          "x": 270,
+          "y": 166,
+          "name": "S2Inner",
+          "opacity": 0.85,
+          "fill": "#2A2D5B",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 10,
+          "id": "q5Voop",
+          "x": 38,
+          "y": 294,
+          "name": "S3Inner",
+          "opacity": 0.85,
+          "fill": "#F0A870",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "ellipse",
+          "id": "XdaaK",
+          "x": 152,
+          "y": 294,
+          "name": "S4Inner",
+          "opacity": 0.85,
+          "fill": "#B5D8F7",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 10,
+          "id": "AExLZ",
+          "x": 270,
+          "y": 294,
+          "name": "S5Inner",
+          "opacity": 0.6,
+          "fill": "#E87A2E",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "ellipse",
+          "id": "sMQ13",
+          "x": 38,
+          "y": 422,
+          "name": "S6Inner",
+          "opacity": 0.7,
+          "fill": "#2A2D5B",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 10,
+          "id": "jHXLZ",
+          "x": 152,
+          "y": 422,
+          "name": "S7Inner",
+          "opacity": 0.9,
+          "fill": "#FFF5C3",
+          "width": 64,
+          "height": 64
+        },
+        {
+          "type": "ellipse",
+          "id": "dvOHj",
+          "x": 270,
+          "y": 422,
+          "name": "S8Inner",
+          "opacity": 0.8,
+          "fill": "#F0A870",
+          "width": 64,
+          "height": 64
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ovD7h",
+      "x": 860,
+      "y": 0,
+      "name": "ボード編集",
+      "clip": true,
+      "width": 393,
+      "height": 852,
+      "fill": "#F2EDE4",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "ceZH5",
+          "x": 0,
+          "y": 0,
+          "name": "EdNavBg",
+          "fill": "#F2EDE4",
+          "width": 393,
+          "height": 96
+        },
+        {
+          "type": "text",
+          "id": "n00wOq",
+          "x": 125,
+          "y": 58,
+          "name": "EdNavTitle",
+          "fill": "#2A2D5B",
+          "content": "夏のシール集め",
+          "fontFamily": "Inter",
+          "fontSize": 17,
+          "fontWeight": "700"
+        },
+        {
+          "type": "icon_font",
+          "id": "m3c7q",
+          "x": 16,
+          "y": 56,
+          "name": "BackIcon",
+          "width": 20,
+          "height": 20,
+          "iconFontName": "chevron-left",
+          "iconFontFamily": "lucide",
+          "fill": "#2A2D5B"
+        },
+        {
+          "type": "text",
+          "id": "MK4gC",
+          "x": 38,
+          "y": 58,
+          "name": "edBackLabel",
+          "fill": "#2A2D5B",
+          "content": "戻る",
+          "fontFamily": "Inter",
+          "fontSize": 17,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "icon_font",
+          "id": "t04a9",
+          "x": 294,
+          "y": 57,
+          "name": "edZoomIcon",
+          "width": 18,
+          "height": 18,
+          "iconFontName": "search",
+          "iconFontFamily": "lucide",
+          "fill": "#E87A2E"
+        },
+        {
+          "type": "icon_font",
+          "id": "UGOAF",
+          "x": 322,
+          "y": 57,
+          "name": "edUndoIcon",
+          "width": 18,
+          "height": 18,
+          "iconFontName": "undo-2",
+          "iconFontFamily": "lucide",
+          "fill": "#E87A2E"
+        },
+        {
+          "type": "icon_font",
+          "id": "yrX3g",
+          "x": 354,
+          "y": 57,
+          "name": "edMenuIcon",
+          "width": 18,
+          "height": 18,
+          "iconFontName": "circle-ellipsis",
+          "iconFontFamily": "lucide",
+          "fill": "#E87A2E"
+        },
+        {
+          "type": "rectangle",
+          "id": "k6rXD",
+          "x": 0,
+          "y": 95,
+          "name": "edNavDivider",
+          "fill": "#E5DDD0",
+          "width": 393,
+          "height": 1
+        },
+        {
+          "type": "frame",
+          "id": "qbFSW",
+          "x": 24,
+          "y": 108,
+          "name": "Canvas",
+          "clip": true,
+          "width": 345,
+          "height": 570,
+          "fill": "#FAF0DE",
+          "cornerRadius": 16,
+          "layout": "none",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "g8GdDA",
+              "x": 40,
+              "y": 40,
+              "name": "canvasBgDot1",
+              "fill": "#2A2D5B08",
+              "width": 4,
+              "height": 4
+            },
+            {
+              "type": "ellipse",
+              "id": "BL8tq",
+              "x": 80,
+              "y": 40,
+              "name": "canvasBgDot2",
+              "fill": "#2A2D5B08",
+              "width": 4,
+              "height": 4
+            },
+            {
+              "type": "ellipse",
+              "id": "y6IQrg",
+              "x": 40,
+              "y": 80,
+              "name": "canvasBgDot3",
+              "fill": "#2A2D5B08",
+              "width": 4,
+              "height": 4
+            },
+            {
+              "type": "ellipse",
+              "id": "SBVrb",
+              "x": 30,
+              "y": 60,
+              "name": "EdSticker1",
+              "opacity": 0.88,
+              "fill": "#E87A2E",
+              "width": 120,
+              "height": 120,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000026",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 8
+              }
+            },
+            {
+              "type": "ellipse",
+              "id": "opuF1",
+              "x": 190,
+              "y": 120,
+              "name": "EdSticker2",
+              "opacity": 0.8,
+              "fill": "#2A2D5B",
+              "width": 95,
+              "height": 95,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000026",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 8
+              }
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 12,
+              "id": "d8guNO",
+              "x": 80,
+              "y": 280,
+              "name": "EdSticker3",
+              "opacity": 0.9,
+              "fill": "#F0A870",
+              "width": 90,
+              "height": 90,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000026",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 8
+              }
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 10,
+              "id": "K94mlY",
+              "x": 230,
+              "y": 360,
+              "name": "EdSticker4",
+              "opacity": 0.85,
+              "fill": "#B5D8F7",
+              "width": 80,
+              "height": 80,
+              "effect": {
+                "type": "shadow",
+                "shadowType": "outer",
+                "color": "#00000026",
+                "offset": {
+                  "x": 0,
+                  "y": 4
+                },
+                "blur": 8
+              }
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 14,
+              "id": "rCaTd",
+              "x": 28,
+              "y": 58,
+              "name": "SelectedBorder",
+              "width": 124,
+              "height": 124,
+              "stroke": {
+                "align": "outside",
+                "thickness": 2,
+                "fill": "#E87A2E"
+              }
+            },
+            {
+              "type": "ellipse",
+              "id": "K0CYra",
+              "x": 23,
+              "y": 53,
+              "name": "Handle1",
+              "fill": "#E87A2E",
+              "width": 10,
+              "height": 10
+            },
+            {
+              "type": "ellipse",
+              "id": "NYhP5",
+              "x": 147,
+              "y": 53,
+              "name": "Handle2",
+              "fill": "#E87A2E",
+              "width": 10,
+              "height": 10
+            },
+            {
+              "type": "ellipse",
+              "id": "gJwoP",
+              "x": 147,
+              "y": 177,
+              "name": "Handle3",
+              "fill": "#E87A2E",
+              "width": 10,
+              "height": 10
+            },
+            {
+              "type": "ellipse",
+              "id": "SRPwy",
+              "x": 23,
+              "y": 177,
+              "name": "Handle4",
+              "fill": "#E87A2E",
+              "width": 10,
+              "height": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "T8PQI",
+          "x": 157,
+          "y": 689,
+          "name": "CollapseHandle",
+          "width": 79,
+          "height": 20,
+          "layout": "vertical",
+          "gap": 3,
+          "children": [
+            {
+              "type": "rectangle",
+              "cornerRadius": 2,
+              "id": "j17nk",
+              "name": "handleBar",
+              "fill": "#A0A2B866",
+              "width": 36,
+              "height": 4
+            },
+            {
+              "type": "icon_font",
+              "id": "T2dvW",
+              "name": "chevDown",
+              "width": 10,
+              "height": 10,
+              "iconFontName": "chevron-down",
+              "iconFontFamily": "lucide",
+              "fill": "#A0A2B8"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NZGA7",
+          "x": 16,
+          "y": 716,
+          "name": "FloatingToolbar",
+          "width": 361,
+          "height": 64,
+          "fill": "#FFFFFF99",
+          "cornerRadius": 32,
+          "gap": 16,
+          "padding": [
+            0,
+            28
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "c7JkAw",
+              "name": "TbAdd",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "tECQX",
+                  "name": "tbAddIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "plus",
+                  "iconFontFamily": "lucide",
+                  "fill": "#E87A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "M8xF1",
+                  "name": "tbAddLabel",
+                  "fill": "#E87A2E",
+                  "content": "追加",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "idG1w",
+              "name": "TbEffect",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "Ci0Qn",
+                  "name": "tbEffectIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "wand-sparkles",
+                  "iconFontFamily": "lucide",
+                  "fill": "#E87A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "SRHRj",
+                  "name": "tbEffectLabel",
+                  "fill": "#E87A2E",
+                  "content": "効果",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "YPM5B",
+              "name": "TbBorder",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "u1glX",
+                  "name": "tbBorderIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "square-dashed",
+                  "iconFontFamily": "lucide",
+                  "fill": "#E87A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "B9xg4n",
+                  "name": "tbBorderLabel",
+                  "fill": "#E87A2E",
+                  "content": "枠線",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "KLorp",
+              "name": "TbFront",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "T1O3TF",
+                  "name": "tbFrontIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "layers",
+                  "iconFontFamily": "lucide",
+                  "fill": "#2A2D5B"
+                },
+                {
+                  "type": "text",
+                  "id": "Yqlte",
+                  "name": "tbFrontLabel",
+                  "fill": "#2A2D5B",
+                  "content": "前面",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "bWYsV",
+              "name": "TbBack",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "L1UVA0",
+                  "name": "tbBackIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "layers",
+                  "iconFontFamily": "lucide",
+                  "fill": "#2A2D5B"
+                },
+                {
+                  "type": "text",
+                  "id": "AQLjV",
+                  "name": "tbBackLabel",
+                  "fill": "#2A2D5B",
+                  "content": "背面",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "Z4RIK",
+              "name": "TbBg",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "FSfZC",
+                  "name": "tbBgIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "palette",
+                  "iconFontFamily": "lucide",
+                  "fill": "#2A2D5B"
+                },
+                {
+                  "type": "text",
+                  "id": "A19X4w",
+                  "name": "tbBgLabel",
+                  "fill": "#2A2D5B",
+                  "content": "背景",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "opg3J",
+              "name": "TbLock",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "SbDSh",
+                  "name": "tbLockIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "lock-open",
+                  "iconFontFamily": "lucide",
+                  "fill": "#E87A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "wILqC",
+                  "name": "tbLockLabel",
+                  "fill": "#E87A2E",
+                  "content": "ロック",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "RbhVa",
+              "name": "TbDelete",
+              "width": 40,
+              "height": 48,
+              "layout": "vertical",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "icon_font",
+                  "id": "VShgE",
+                  "name": "tbDeleteIcon",
+                  "width": 24,
+                  "height": 24,
+                  "iconFontName": "trash-2",
+                  "iconFontFamily": "lucide",
+                  "fill": "#E87A2E"
+                },
+                {
+                  "type": "text",
+                  "id": "cEf6r",
+                  "name": "tbDeleteLabel",
+                  "fill": "#E87A2E",
+                  "content": "削除",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "600"
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "C6tYJ",
+      "x": 1290,
+      "y": 0,
+      "name": "ペイウォール",
+      "clip": true,
+      "width": 393,
+      "height": 852,
+      "fill": "#FAF0DE",
+      "layout": "none",
+      "children": [
+        {
+          "type": "text",
+          "id": "bmzrI",
+          "x": 340,
+          "y": 16,
+          "name": "LaterBtn",
+          "fill": "#A0A2B8",
+          "content": "あとで",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "500"
+        },
+        {
+          "type": "ellipse",
+          "id": "xDvu7",
+          "x": 157,
+          "y": 44,
+          "name": "IconOuter",
+          "fill": "#E87A2E0F",
+          "width": 80,
+          "height": 80
+        },
+        {
+          "type": "ellipse",
+          "id": "JeA0p",
+          "x": 166,
+          "y": 54,
+          "name": "IconInner",
+          "fill": "#E87A2E21",
+          "width": 62,
+          "height": 62
+        },
+        {
+          "type": "icon_font",
+          "id": "dtgc1",
+          "x": 182,
+          "y": 72,
+          "name": "pwCrownIcon",
+          "width": 30,
+          "height": 30,
+          "iconFontName": "crown",
+          "iconFontFamily": "lucide",
+          "fill": "#E87A2E"
+        },
+        {
+          "type": "text",
+          "id": "hY1hc",
+          "x": 105,
+          "y": 140,
+          "name": "PwTitle",
+          "fill": "#2A2D5B",
+          "content": "StickerBoard Pro",
+          "fontFamily": "Inter",
+          "fontSize": 22,
+          "fontWeight": "700"
+        },
+        {
+          "type": "text",
+          "id": "t5QUNf",
+          "x": 118,
+          "y": 170,
+          "name": "PwSubtitle",
+          "fill": "#6B6D8E",
+          "content": "すべての機能をアンロック",
+          "fontFamily": "Inter",
+          "fontSize": 14,
+          "fontWeight": "normal"
+        },
+        {
+          "type": "frame",
+          "id": "OgiKw",
+          "x": 24,
+          "y": 200,
+          "name": "FeatureCard",
+          "width": 345,
+          "height": 245,
+          "fill": "#FFFEF8",
+          "cornerRadius": 16,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#0000000F",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 8
+          },
+          "layout": "vertical",
+          "children": [
+            {
+              "type": "frame",
+              "id": "uQBUH",
+              "name": "FR1",
+              "width": "fill_container",
+              "height": 48,
+              "gap": 14,
+              "padding": [
+                0,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "eRA2l",
+                  "name": "iw1",
+                  "width": 36,
+                  "height": 36,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "cpIj1",
+                      "x": 0,
+                      "y": 0,
+                      "name": "ibg1",
+                      "fill": "#E87A2E1F",
+                      "width": 36,
+                      "height": 36
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "lo2Nd",
+                      "x": 9,
+                      "y": 9,
+                      "name": "ico1",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "star",
+                      "iconFontFamily": "lucide",
+                      "fill": "#E87A2E"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "MYHQr",
+                  "name": "fr1text",
+                  "fill": "#2A2D5B",
+                  "content": "シール保存",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "I9H3hr",
+                  "name": "fr1spacer",
+                  "fill": "#00000000",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "dcYiB",
+                  "name": "fr1badge",
+                  "height": 24,
+                  "fill": "#E87A2E1A",
+                  "cornerRadius": 12,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "yqZ1e",
+                      "name": "fr1badgeText",
+                      "fill": "#E87A2E",
+                      "content": "無制限",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "ZigER",
+              "name": "fr1div",
+              "fill": "#E5DDD0",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "AYc7A",
+              "name": "FR2",
+              "width": "fill_container",
+              "height": 48,
+              "gap": 14,
+              "padding": [
+                0,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "ouYcI",
+                  "name": "iw2",
+                  "width": 36,
+                  "height": 36,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "vtrKv",
+                      "x": 0,
+                      "y": 0,
+                      "name": "ibg2",
+                      "fill": "#2A2D5B1F",
+                      "width": 36,
+                      "height": 36
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "Z2etA",
+                      "x": 9,
+                      "y": 9,
+                      "name": "ico2",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "copy",
+                      "iconFontFamily": "lucide",
+                      "fill": "#2A2D5B"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "xKt9z",
+                  "name": "fr2text",
+                  "fill": "#2A2D5B",
+                  "content": "ボード作成",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "OVYyf",
+                  "name": "fr2spacer",
+                  "fill": "#00000000",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "dpSCx",
+                  "name": "fr2badge",
+                  "height": 24,
+                  "fill": "#E87A2E1A",
+                  "cornerRadius": 12,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "psbTR",
+                      "name": "fr2badgeText",
+                      "fill": "#E87A2E",
+                      "content": "無制限",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "b9Uvg",
+              "name": "fr2div",
+              "fill": "#E5DDD0",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "KWvOd",
+              "name": "FR3",
+              "width": "fill_container",
+              "height": 48,
+              "gap": 14,
+              "padding": [
+                0,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "sDa7n",
+                  "name": "iw3",
+                  "width": 36,
+                  "height": 36,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "uVIaj",
+                      "x": 0,
+                      "y": 0,
+                      "name": "ibg3",
+                      "fill": "#F0A8701F",
+                      "width": 36,
+                      "height": 36
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "n3FcYa",
+                      "x": 9,
+                      "y": 9,
+                      "name": "ico3",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "square-dashed",
+                      "iconFontFamily": "lucide",
+                      "fill": "#F0A870"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "yM0oJ",
+                  "name": "fr3text",
+                  "fill": "#2A2D5B",
+                  "content": "枠線バリエーション",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "GaaeY",
+                  "name": "fr3spacer",
+                  "fill": "#00000000",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "xGvBv",
+                  "name": "fr3badge",
+                  "height": 24,
+                  "fill": "#E87A2E1A",
+                  "cornerRadius": 12,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "B0cMQ",
+                      "name": "fr3badgeText",
+                      "fill": "#E87A2E",
+                      "content": "全開放",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "kWAgr",
+              "name": "fr3div",
+              "fill": "#E5DDD0",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "PZ4Nx",
+              "name": "FR4",
+              "width": "fill_container",
+              "height": 48,
+              "gap": 14,
+              "padding": [
+                0,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "EJY0D",
+                  "name": "iw4",
+                  "width": 36,
+                  "height": 36,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "zfPdv",
+                      "x": 0,
+                      "y": 0,
+                      "name": "ibg4",
+                      "fill": "#B5D8F71F",
+                      "width": 36,
+                      "height": 36
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "vZ0AV",
+                      "x": 9,
+                      "y": 9,
+                      "name": "ico4",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "palette",
+                      "iconFontFamily": "lucide",
+                      "fill": "#B5D8F7"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "HukGv",
+                  "name": "fr4text",
+                  "fill": "#2A2D5B",
+                  "content": "背景パターン",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "D92WaJ",
+                  "name": "fr4spacer",
+                  "fill": "#00000000",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "WlxvE",
+                  "name": "fr4badge",
+                  "height": 24,
+                  "fill": "#E87A2E1A",
+                  "cornerRadius": 12,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "ItSl3",
+                      "name": "fr4badgeText",
+                      "fill": "#E87A2E",
+                      "content": "全開放",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "dqPpO",
+              "name": "fr4div",
+              "fill": "#E5DDD0",
+              "width": "fill_container",
+              "height": 1
+            },
+            {
+              "type": "frame",
+              "id": "DAegs",
+              "name": "FR5",
+              "width": "fill_container",
+              "height": 48,
+              "gap": 14,
+              "padding": [
+                0,
+                16
+              ],
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "frame",
+                  "id": "xxDs0",
+                  "name": "iw5",
+                  "width": 36,
+                  "height": 36,
+                  "layout": "none",
+                  "children": [
+                    {
+                      "type": "rectangle",
+                      "cornerRadius": 9,
+                      "id": "d1qbo",
+                      "x": 0,
+                      "y": 0,
+                      "name": "ibg5",
+                      "fill": "#2A2D5B1F",
+                      "width": 36,
+                      "height": 36
+                    },
+                    {
+                      "type": "icon_font",
+                      "id": "hV0RR",
+                      "x": 9,
+                      "y": 9,
+                      "name": "ico5",
+                      "width": 18,
+                      "height": 18,
+                      "iconFontName": "download",
+                      "iconFontFamily": "lucide",
+                      "fill": "#2A2D5B"
+                    }
+                  ]
+                },
+                {
+                  "type": "text",
+                  "id": "gFDux",
+                  "name": "fr5text",
+                  "fill": "#2A2D5B",
+                  "content": "画像書き出し",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                },
+                {
+                  "type": "rectangle",
+                  "id": "B3LjX",
+                  "name": "fr5spacer",
+                  "fill": "#00000000",
+                  "width": "fill_container",
+                  "height": 1
+                },
+                {
+                  "type": "frame",
+                  "id": "wATPy",
+                  "name": "fr5badge",
+                  "height": 24,
+                  "fill": "#E87A2E1A",
+                  "cornerRadius": 12,
+                  "padding": [
+                    0,
+                    10
+                  ],
+                  "children": [
+                    {
+                      "type": "text",
+                      "id": "QnyYV",
+                      "name": "fr5badgeText",
+                      "fill": "#E87A2E",
+                      "content": "ロゴなし",
+                      "fontFamily": "Inter",
+                      "fontSize": 12,
+                      "fontWeight": "700"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "tY1dj",
+          "x": 24,
+          "y": 452,
+          "name": "PricingCard",
+          "width": 345,
+          "height": 120,
+          "fill": "#FFFEF8",
+          "cornerRadius": 16,
+          "stroke": {
+            "align": "outside",
+            "thickness": 2,
+            "fill": "#E87A2E"
+          },
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#E87A2E26",
+            "offset": {
+              "x": 0,
+              "y": 4
+            },
+            "blur": 12
+          },
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            24,
+            20
+          ],
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "frame",
+              "id": "Y3QVOE",
+              "name": "discountBadge",
+              "height": 26,
+              "fill": "#E87A2E",
+              "cornerRadius": 13,
+              "padding": [
+                0,
+                12
+              ],
+              "children": [
+                {
+                  "type": "text",
+                  "id": "cgzgM",
+                  "name": "discountText",
+                  "fill": "#FFFFFF",
+                  "content": "40% おトク",
+                  "fontFamily": "Inter",
+                  "fontSize": 12,
+                  "fontWeight": "700"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "m6EQY1",
+              "name": "priceRow",
+              "gap": 4,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "oe8XI",
+                  "name": "priceMain",
+                  "fill": "#2A2D5B",
+                  "content": "¥1,200",
+                  "fontFamily": "Inter",
+                  "fontSize": 30,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "jNKzw",
+                  "name": "priceUnit",
+                  "fill": "#6B6D8E",
+                  "content": "/年",
+                  "fontFamily": "Inter",
+                  "fontSize": 15,
+                  "fontWeight": "500"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "FKq2P",
+              "name": "priceMonthly",
+              "fill": "#6B6D8E",
+              "content": "月あたり ¥100",
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "pytBY",
+          "x": 24,
+          "y": 586,
+          "name": "CTABtn",
+          "width": 345,
+          "height": 50,
+          "fill": "#E87A2E",
+          "cornerRadius": 28,
+          "effect": {
+            "type": "shadow",
+            "shadowType": "outer",
+            "color": "#E87A2E66",
+            "offset": {
+              "x": 0,
+              "y": 6
+            },
+            "blur": 12
+          },
+          "justifyContent": "center",
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "text",
+              "id": "AFrgM",
+              "name": "ctaText",
+              "fill": "#FFFFFF",
+              "content": "Proではじめる（年額）",
+              "fontFamily": "Inter",
+              "fontSize": 17,
+              "fontWeight": "700"
+            }
+          ]
+        },
+        {
+          "type": "text",
+          "id": "KvuoY",
+          "x": 90,
+          "y": 648,
+          "name": "MonthlyBtn",
+          "fill": "#6B6D8E",
+          "content": "月額プランで始める ¥150/月",
+          "fontFamily": "Inter",
+          "fontSize": 13,
+          "fontWeight": "500"
+        },
+        {
+          "type": "text",
+          "id": "lQjfZ",
+          "x": 162,
+          "y": 676,
+          "name": "RestoreBtn",
+          "fill": "#A0A2B8",
+          "content": "購入を復元",
+          "fontFamily": "Inter",
+          "fontSize": 12,
+          "fontWeight": "500"
+        },
+        {
+          "type": "frame",
+          "id": "E19VQw",
+          "x": 118,
+          "y": 698,
+          "name": "FooterLinks",
+          "width": 157,
+          "height": 20,
+          "gap": 16,
+          "children": [
+            {
+              "type": "text",
+              "id": "M2YCuk",
+              "name": "termsLink",
+              "fill": "#A0A2B8",
+              "content": "利用規約",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "OtnVF",
+              "name": "privacyLink",
+              "fill": "#A0A2B8",
+              "content": "プライバシーポリシー",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "WUREt",
+      "x": 0,
+      "y": 1100,
+      "name": "投稿1_推しシールボード公開",
+      "clip": true,
+      "width": 400,
+      "height": 500,
+      "fill": "#FAF0DE",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "DgU2c",
+          "name": "p1header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "#FAF0DE",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "wmhPA",
+              "name": "p1avatar",
+              "fill": "#E87A2E",
+              "width": 36,
+              "height": 36
+            },
+            {
+              "type": "frame",
+              "id": "EZeJD",
+              "name": "p1userinfo",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "UBQZN",
+                  "name": "p1username",
+                  "fill": "#2A2D5B",
+                  "content": "stickerboard_life",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "HUqgm",
+                  "name": "p1subtitle",
+                  "opacity": 0.6,
+                  "fill": "#2A2D5B",
+                  "content": "シール沼の住人",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NHBBB",
+          "name": "p1board",
+          "clip": true,
+          "width": "fill_container",
+          "height": 300,
+          "fill": "#2A2D5B",
+          "layout": "none",
+          "children": [
+            {
+              "type": "rectangle",
+              "cornerRadius": 12,
+              "id": "CQsMq",
+              "x": 20,
+              "y": 20,
+              "name": "p1boardInner",
+              "fill": "#1E2040",
+              "width": 360,
+              "height": 260
+            },
+            {
+              "type": "ellipse",
+              "id": "nLuGD",
+              "x": 50,
+              "y": 40,
+              "name": "p1s1",
+              "fill": "#E87A2E",
+              "width": 80,
+              "height": 80
+            },
+            {
+              "type": "text",
+              "id": "oPKNt",
+              "x": 72,
+              "y": 56,
+              "name": "p1s1txt",
+              "content": "⭐",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 16,
+              "id": "ib7eU",
+              "x": 160,
+              "y": 30,
+              "name": "p1s2",
+              "fill": "#FAF0DE",
+              "width": 90,
+              "height": 90
+            },
+            {
+              "type": "text",
+              "id": "knNJ0",
+              "x": 176,
+              "y": 44,
+              "name": "p1s2txt",
+              "content": "🌸",
+              "fontFamily": "Inter",
+              "fontSize": 40,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "ellipse",
+              "id": "mWo48",
+              "x": 280,
+              "y": 50,
+              "name": "p1s3",
+              "opacity": 0.8,
+              "fill": "#E87A2E",
+              "width": 70,
+              "height": 70
+            },
+            {
+              "type": "text",
+              "id": "AbZvX",
+              "x": 297,
+              "y": 62,
+              "name": "p1s3txt",
+              "content": "🎀",
+              "fontFamily": "Inter",
+              "fontSize": 30,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 20,
+              "id": "mebta",
+              "x": 60,
+              "y": 150,
+              "name": "p1s4",
+              "opacity": 0.9,
+              "fill": "#FAF0DE",
+              "width": 85,
+              "height": 85
+            },
+            {
+              "type": "text",
+              "id": "gum29",
+              "x": 76,
+              "y": 163,
+              "name": "p1s4txt",
+              "content": "🦋",
+              "fontFamily": "Inter",
+              "fontSize": 38,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "ellipse",
+              "id": "Xigqw",
+              "x": 170,
+              "y": 155,
+              "name": "p1s5",
+              "fill": "#E87A2E",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "T1mjNk",
+              "x": 190,
+              "y": 170,
+              "name": "p1s5txt",
+              "content": "💫",
+              "fontFamily": "Inter",
+              "fontSize": 34,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 18,
+              "id": "v9AZy",
+              "x": 270,
+              "y": 148,
+              "name": "p1s6",
+              "opacity": 0.85,
+              "fill": "#FAF0DE",
+              "width": 80,
+              "height": 80
+            },
+            {
+              "type": "text",
+              "id": "fHtZh",
+              "x": 286,
+              "y": 162,
+              "name": "p1s6txt",
+              "content": "🌈",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "B9FEX",
+          "name": "p1caption",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "frame",
+              "id": "uobob",
+              "name": "p1likes",
+              "gap": 6,
+              "alignItems": "center",
+              "children": [
+                {
+                  "type": "text",
+                  "id": "f4xf4D",
+                  "name": "p1heartIcon",
+                  "content": "❤️",
+                  "fontFamily": "Inter",
+                  "fontSize": 20,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "Q1bGs",
+                  "name": "p1likeCount",
+                  "fill": "#2A2D5B",
+                  "content": "いいね！ 247件",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                }
+              ]
+            },
+            {
+              "type": "text",
+              "id": "aDGru",
+              "name": "p1captionText",
+              "fill": "#2A2D5B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "推しカラーだけで埋めたボード完成した🌸 ぜんぶデジタルだから剥がれる心配なし…最高すぎ",
+              "lineHeight": 1.5,
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "S25QsR",
+              "name": "p1tags",
+              "fill": "#E87A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "#推しシールボード #シールコレクション #推し活 #シール沼の住人",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "ClLJF",
+      "x": 450,
+      "y": 1100,
+      "name": "投稿2_BeforeAfter",
+      "clip": true,
+      "width": 400,
+      "height": 500,
+      "fill": "#FAF0DE",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "ZsXhG",
+          "name": "p2header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "#FAF0DE",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "pmbyK",
+              "name": "p2avatar",
+              "fill": "#2A2D5B",
+              "width": 36,
+              "height": 36
+            },
+            {
+              "type": "frame",
+              "id": "z9tzka",
+              "name": "p2userinfo",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "wc0IK",
+                  "name": "p2username",
+                  "fill": "#2A2D5B",
+                  "content": "stickerboard_life",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "Ixnq4",
+                  "name": "p2subtitle",
+                  "opacity": 0.6,
+                  "fill": "#2A2D5B",
+                  "content": "シール沼の住人",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "KNgTe",
+          "name": "p2slide",
+          "clip": true,
+          "width": "fill_container",
+          "height": 300,
+          "children": [
+            {
+              "type": "frame",
+              "id": "J6maqK",
+              "name": "p2before",
+              "width": "fill_container",
+              "height": 300,
+              "fill": "#FFF8EE",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "F6U94N",
+                  "x": 8,
+                  "y": 8,
+                  "name": "p2beforeLabel",
+                  "fill": "#2A2D5B",
+                  "width": 72,
+                  "height": 24
+                },
+                {
+                  "type": "text",
+                  "id": "WxtoB",
+                  "x": 16,
+                  "y": 14,
+                  "name": "p2beforeLabelTxt",
+                  "fill": "#FAF0DE",
+                  "content": "BEFORE",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "text",
+                  "id": "l4DAP0",
+                  "x": 20,
+                  "y": 60,
+                  "name": "p2b1",
+                  "rotation": -14.999999999999998,
+                  "content": "🏷️",
+                  "fontFamily": "Inter",
+                  "fontSize": 40,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "iktgX",
+                  "x": 80,
+                  "y": 45,
+                  "name": "p2b2",
+                  "rotation": 20,
+                  "content": "⭐",
+                  "fontFamily": "Inter",
+                  "fontSize": 32,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "vMKfC",
+                  "x": 40,
+                  "y": 130,
+                  "name": "p2b3",
+                  "rotation": -8,
+                  "content": "🌸",
+                  "fontFamily": "Inter",
+                  "fontSize": 36,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "dzWul",
+                  "x": 110,
+                  "y": 100,
+                  "name": "p2b4",
+                  "rotation": 25,
+                  "content": "🎀",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "D2umnI",
+                  "x": 60,
+                  "y": 200,
+                  "name": "p2b5",
+                  "rotation": -20,
+                  "content": "🦋",
+                  "fontFamily": "Inter",
+                  "fontSize": 34,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "text",
+                  "id": "YyLKh",
+                  "x": 130,
+                  "y": 165,
+                  "name": "p2b6",
+                  "rotation": 10,
+                  "content": "💫",
+                  "fontFamily": "Inter",
+                  "fontSize": 30,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "rectangle",
+              "id": "IkiWa",
+              "name": "p2divider",
+              "fill": "#E87A2E",
+              "width": 2,
+              "height": 300
+            },
+            {
+              "type": "frame",
+              "id": "PPFup",
+              "name": "p2after",
+              "width": "fill_container",
+              "height": 300,
+              "fill": "#2A2D5B",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "UbVtf",
+                  "x": 8,
+                  "y": 8,
+                  "name": "p2afterLabel",
+                  "fill": "#E87A2E",
+                  "width": 64,
+                  "height": 24
+                },
+                {
+                  "type": "text",
+                  "id": "RG1c2",
+                  "x": 17,
+                  "y": 14,
+                  "name": "p2afterLabelTxt",
+                  "fill": "#FAF0DE",
+                  "content": "AFTER",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "700"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "P8knq",
+                  "x": 20,
+                  "y": 50,
+                  "name": "p2a1",
+                  "fill": "#E87A2E",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "uKMKM",
+                  "x": 36,
+                  "y": 65,
+                  "name": "p2a1txt",
+                  "content": "⭐",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "gKZ0h",
+                  "x": 100,
+                  "y": 50,
+                  "name": "p2a2",
+                  "fill": "#FAF0DE",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "fdQv9",
+                  "x": 116,
+                  "y": 65,
+                  "name": "p2a2txt",
+                  "content": "🌸",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "W5foJ",
+                  "x": 20,
+                  "y": 130,
+                  "name": "p2a3",
+                  "fill": "#FAF0DE",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "U3yZwM",
+                  "x": 36,
+                  "y": 145,
+                  "name": "p2a3txt",
+                  "content": "🎀",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "u24uY",
+                  "x": 100,
+                  "y": 130,
+                  "name": "p2a4",
+                  "fill": "#E87A2E",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "LM2qv",
+                  "x": 116,
+                  "y": 145,
+                  "name": "p2a4txt",
+                  "content": "🦋",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "G47p3g",
+                  "x": 20,
+                  "y": 210,
+                  "name": "p2a5",
+                  "opacity": 0.7,
+                  "fill": "#E87A2E",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "kS7x8",
+                  "x": 36,
+                  "y": 225,
+                  "name": "p2a5txt",
+                  "content": "💫",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 12,
+                  "id": "yFujG",
+                  "x": 100,
+                  "y": 210,
+                  "name": "p2a6",
+                  "fill": "#FAF0DE",
+                  "width": 60,
+                  "height": 60
+                },
+                {
+                  "type": "text",
+                  "id": "wtasb",
+                  "x": 116,
+                  "y": 225,
+                  "name": "p2a6txt",
+                  "content": "🌈",
+                  "fontFamily": "Inter",
+                  "fontSize": 28,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "WIsXh",
+          "name": "p2caption",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "NQrKS",
+              "name": "p2captionText",
+              "fill": "#2A2D5B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "箱の底に眠ってたシールたちをデジタル化したら気持ちよすぎた…これもう戻れない🫠",
+              "lineHeight": 1.5,
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "Qz19A",
+              "name": "p2tags",
+              "fill": "#E87A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "#シール整理 #推し活 #シールコレクション #今日のひと貼り",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "PfIGE",
+      "x": 900,
+      "y": 1100,
+      "name": "投稿3_フィルター比較",
+      "clip": true,
+      "width": 400,
+      "height": 500,
+      "fill": "#1A1A2E",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "Zu6jP",
+          "name": "p3header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "#1A1A2E",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "U5tEfr",
+              "name": "p3avatar",
+              "fill": "#E87A2E",
+              "width": 36,
+              "height": 36
+            },
+            {
+              "type": "frame",
+              "id": "fdZO1",
+              "name": "p3userinfo",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "k8Idb",
+                  "name": "p3username",
+                  "fill": "#FAF0DE",
+                  "content": "stickerboard_life",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "VkXEM",
+                  "name": "p3subtitle",
+                  "opacity": 0.6,
+                  "fill": "#FAF0DE",
+                  "content": "シール沼の住人",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "Oi8rL",
+          "name": "p3imgArea",
+          "clip": true,
+          "width": "fill_container",
+          "height": 260,
+          "children": [
+            {
+              "type": "frame",
+              "id": "R9pBs",
+              "name": "p3left",
+              "width": "fill_container",
+              "height": 260,
+              "fill": "#2A2D5B",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "p111g8",
+                  "x": 8,
+                  "y": 8,
+                  "name": "p3leftLabel",
+                  "opacity": 0.2,
+                  "fill": "#FAF0DE",
+                  "width": 70,
+                  "height": 22
+                },
+                {
+                  "type": "text",
+                  "id": "NPZJ7",
+                  "x": 12,
+                  "y": 13,
+                  "name": "p3leftLabelTxt",
+                  "fill": "#FAF0DE",
+                  "content": "フィルターなし",
+                  "fontFamily": "Inter",
+                  "fontSize": 9,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 24,
+                  "id": "ldCKt",
+                  "x": 35,
+                  "y": 60,
+                  "name": "p3leftSticker",
+                  "fill": "#FAF0DE",
+                  "width": 120,
+                  "height": 120
+                },
+                {
+                  "type": "text",
+                  "id": "cy271",
+                  "x": 63,
+                  "y": 80,
+                  "name": "p3leftStickerTxt",
+                  "content": "🌸",
+                  "fontFamily": "Inter",
+                  "fontSize": 64,
+                  "fontWeight": "normal"
+                }
+              ]
+            },
+            {
+              "type": "frame",
+              "id": "tkrzG",
+              "name": "p3right",
+              "width": "fill_container",
+              "height": 260,
+              "fill": "#0D0D1A",
+              "layout": "none",
+              "children": [
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 4,
+                  "id": "X8Z1rp",
+                  "x": 8,
+                  "y": 8,
+                  "name": "p3rightLabel",
+                  "fill": "#E87A2E",
+                  "width": 96,
+                  "height": 22
+                },
+                {
+                  "type": "text",
+                  "id": "zKMI5",
+                  "x": 12,
+                  "y": 13,
+                  "name": "p3rightLabelTxt",
+                  "fill": "#FAF0DE",
+                  "content": "✨ ホログラム",
+                  "fontFamily": "Inter",
+                  "fontSize": 9,
+                  "fontWeight": "normal"
+                },
+                {
+                  "type": "rectangle",
+                  "cornerRadius": 28,
+                  "id": "XZpUa",
+                  "x": 20,
+                  "y": 45,
+                  "name": "p3rightBg",
+                  "fill": {
+                    "type": "gradient",
+                    "gradientType": "angular",
+                    "enabled": true,
+                    "rotation": 0,
+                    "size": {
+                      "width": 1,
+                      "height": 1
+                    },
+                    "colors": [
+                      {
+                        "color": "#FF6B9D",
+                        "position": 0
+                      },
+                      {
+                        "color": "#FFD700",
+                        "position": 0.25
+                      },
+                      {
+                        "color": "#00E5FF",
+                        "position": 0.5
+                      },
+                      {
+                        "color": "#FF6B9D",
+                        "position": 0.75
+                      },
+                      {
+                        "color": "#A855F7",
+                        "position": 1
+                      }
+                    ]
+                  },
+                  "width": 145,
+                  "height": 145
+                },
+                {
+                  "type": "text",
+                  "id": "e5n2L",
+                  "x": 48,
+                  "y": 68,
+                  "name": "p3rightStickerTxt",
+                  "content": "🌸",
+                  "fontFamily": "Inter",
+                  "fontSize": 64,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "AbXni",
+          "name": "p3caption",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "E0oHm",
+              "name": "p3sparkles",
+              "content": "✨✨✨",
+              "fontFamily": "Inter",
+              "fontSize": 16,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "Yi2rI",
+              "name": "p3captionText",
+              "fill": "#FAF0DE",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "ホログラムフィルターかけたら次元が変わった件について🌈 同じシールなのに全然違うよ",
+              "lineHeight": 1.5,
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "Oa0Ae",
+              "name": "p3tags",
+              "fill": "#E87A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "#ホログラム #キラキラ #シールコレクション #シール沼の住人",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "zLcqf",
+      "x": 1350,
+      "y": 1100,
+      "name": "投稿4_配色縛りボード",
+      "clip": true,
+      "width": 400,
+      "height": 500,
+      "fill": "#FAF0DE",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "WMfla",
+          "name": "p4header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "#FAF0DE",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "WnXQA",
+              "name": "p4avatar",
+              "fill": "#E87A2E",
+              "width": 36,
+              "height": 36
+            },
+            {
+              "type": "frame",
+              "id": "lClUV",
+              "name": "p4userinfo",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "jMinb",
+                  "name": "p4username",
+                  "fill": "#2A2D5B",
+                  "content": "stickerboard_life",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "HhJ89",
+                  "name": "p4subtitle",
+                  "opacity": 0.6,
+                  "fill": "#2A2D5B",
+                  "content": "シール沼の住人",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "V8kH4",
+          "name": "p4board",
+          "clip": true,
+          "width": "fill_container",
+          "height": 300,
+          "fill": "#FFF0F5",
+          "layout": "none",
+          "children": [
+            {
+              "type": "rectangle",
+              "cornerRadius": 16,
+              "id": "UYS6t",
+              "x": 16,
+              "y": 16,
+              "name": "p4badge",
+              "fill": "#E87A2E",
+              "width": 140,
+              "height": 32
+            },
+            {
+              "type": "text",
+              "id": "gWW7e",
+              "x": 22,
+              "y": 24,
+              "name": "p4badgeTxt",
+              "fill": "#FAF0DE",
+              "content": "💗 推し色縛りボード",
+              "fontFamily": "Inter",
+              "fontSize": 12,
+              "fontWeight": "700"
+            },
+            {
+              "type": "ellipse",
+              "id": "boPsr",
+              "x": 30,
+              "y": 70,
+              "name": "p4s1",
+              "fill": "#FFB7C5",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "Y34ofH",
+              "x": 49,
+              "y": 87,
+              "name": "p4s1txt",
+              "content": "🌸",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 20,
+              "id": "bM3zA",
+              "x": 130,
+              "y": 65,
+              "name": "p4s2",
+              "fill": "#FF8FAB",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "aceDu",
+              "x": 148,
+              "y": 82,
+              "name": "p4s2txt",
+              "content": "🎀",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "ellipse",
+              "id": "Gqiyf",
+              "x": 240,
+              "y": 70,
+              "name": "p4s3",
+              "fill": "#FFB7C5",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "FWcHO",
+              "x": 259,
+              "y": 87,
+              "name": "p4s3txt",
+              "content": "💕",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 20,
+              "id": "edjJ1",
+              "x": 60,
+              "y": 170,
+              "name": "p4s4",
+              "fill": "#FF8FAB",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "Tqq7P",
+              "x": 78,
+              "y": 187,
+              "name": "p4s4txt",
+              "content": "🌷",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "ellipse",
+              "id": "KkmvE",
+              "x": 170,
+              "y": 170,
+              "name": "p4s5",
+              "fill": "#FFB7C5",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "Vs5nH",
+              "x": 189,
+              "y": 187,
+              "name": "p4s5txt",
+              "content": "🫶",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 20,
+              "id": "BwU48",
+              "x": 275,
+              "y": 168,
+              "name": "p4s6",
+              "fill": "#FF8FAB",
+              "width": 75,
+              "height": 75
+            },
+            {
+              "type": "text",
+              "id": "KQkS2",
+              "x": 293,
+              "y": 185,
+              "name": "p4s6txt",
+              "content": "🎵",
+              "fontFamily": "Inter",
+              "fontSize": 36,
+              "fontWeight": "normal"
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "dcy5P",
+          "name": "p4caption",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "SuT8Q",
+              "name": "p4captionText",
+              "fill": "#2A2D5B",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "推し色（ピンク）だけで埋めたボード完成💗 縛りプレイが一番楽しいって気づいてしまった",
+              "lineHeight": 1.5,
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "TRKS5",
+              "name": "p4tags",
+              "fill": "#E87A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "#推し色縛り #推しシールボード #推し活 #シール沼の住人",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "aU6N7",
+      "x": 1800,
+      "y": 1100,
+      "name": "投稿5_今日のひと貼り",
+      "clip": true,
+      "width": 400,
+      "height": 500,
+      "fill": "#2A2D5B",
+      "layout": "vertical",
+      "children": [
+        {
+          "type": "frame",
+          "id": "thngw",
+          "name": "p5header",
+          "width": "fill_container",
+          "height": 56,
+          "fill": "#2A2D5B",
+          "gap": 10,
+          "padding": [
+            0,
+            16
+          ],
+          "alignItems": "center",
+          "children": [
+            {
+              "type": "ellipse",
+              "id": "ktPLC",
+              "name": "p5avatar",
+              "fill": "#E87A2E",
+              "width": 36,
+              "height": 36
+            },
+            {
+              "type": "frame",
+              "id": "z70w7",
+              "name": "p5userinfo",
+              "width": "fill_container",
+              "layout": "vertical",
+              "gap": 2,
+              "children": [
+                {
+                  "type": "text",
+                  "id": "NLXqr",
+                  "name": "p5username",
+                  "fill": "#FAF0DE",
+                  "content": "stickerboard_life",
+                  "fontFamily": "Inter",
+                  "fontSize": 13,
+                  "fontWeight": "600"
+                },
+                {
+                  "type": "text",
+                  "id": "TZrqw",
+                  "name": "p5subtitle",
+                  "opacity": 0.6,
+                  "fill": "#FAF0DE",
+                  "content": "シール沼の住人",
+                  "fontFamily": "Inter",
+                  "fontSize": 10,
+                  "fontWeight": "normal"
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "v2uWs",
+          "name": "p5board",
+          "clip": true,
+          "width": "fill_container",
+          "height": 300,
+          "fill": "#1E2040",
+          "layout": "none",
+          "children": [
+            {
+              "type": "text",
+              "id": "MxtVW",
+              "x": 130,
+              "y": 30,
+              "name": "p5dateTxt",
+              "fill": "#E87A2E",
+              "content": "Day 23",
+              "fontFamily": "Inter",
+              "fontSize": 32,
+              "fontWeight": "700"
+            },
+            {
+              "type": "text",
+              "id": "CoMy8",
+              "x": 128,
+              "y": 72,
+              "name": "p5dayLabel",
+              "opacity": 0.7,
+              "fill": "#FAF0DE",
+              "content": "今日のひと貼り",
+              "fontFamily": "Inter",
+              "fontSize": 14,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "rectangle",
+              "cornerRadius": 32,
+              "id": "sgPGv",
+              "x": 120,
+              "y": 110,
+              "name": "p5mainSticker",
+              "fill": "#E87A2E",
+              "width": 160,
+              "height": 160
+            },
+            {
+              "type": "text",
+              "id": "cd2Tu",
+              "x": 150,
+              "y": 130,
+              "name": "p5mainStickerTxt",
+              "content": "⭐",
+              "fontFamily": "Inter",
+              "fontSize": 90,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "ellipse",
+              "id": "z4w45",
+              "x": 40,
+              "y": 130,
+              "name": "p5dot1",
+              "opacity": 0.5,
+              "fill": "#E87A2E",
+              "width": 16,
+              "height": 16
+            },
+            {
+              "type": "ellipse",
+              "id": "KGu1Z",
+              "x": 340,
+              "y": 150,
+              "name": "p5dot2",
+              "opacity": 0.4,
+              "fill": "#FAF0DE",
+              "width": 12,
+              "height": 12
+            },
+            {
+              "type": "ellipse",
+              "id": "tBJdG",
+              "x": 60,
+              "y": 230,
+              "name": "p5dot3",
+              "opacity": 0.3,
+              "fill": "#E87A2E",
+              "width": 10,
+              "height": 10
+            }
+          ]
+        },
+        {
+          "type": "frame",
+          "id": "NHkpz",
+          "name": "p5caption",
+          "width": "fill_container",
+          "layout": "vertical",
+          "gap": 8,
+          "padding": [
+            12,
+            16
+          ],
+          "children": [
+            {
+              "type": "text",
+              "id": "HpfvF",
+              "name": "p5captionText",
+              "fill": "#FAF0DE",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "推しのシール、今日も1枚追加した⭐ 毎日続けて23日目…これが楽しすぎてやばい",
+              "lineHeight": 1.5,
+              "fontFamily": "Inter",
+              "fontSize": 13,
+              "fontWeight": "normal"
+            },
+            {
+              "type": "text",
+              "id": "o3Oai9",
+              "name": "p5tags",
+              "fill": "#E87A2E",
+              "textGrowth": "fixed-width",
+              "width": "fill_container",
+              "content": "#今日のひと貼り #シールコレクション #推し活 #シール沼の住人",
+              "fontFamily": "Inter",
+              "fontSize": 11,
+              "fontWeight": "normal"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "type": "text",
+      "id": "Z2JpbE",
+      "x": 0,
+      "y": 1831,
+      "name": "bgLabel",
+      "fill": "#2A2D5B",
+      "content": "🖼️ Instagram背景素材（400×400px）",
+      "fontFamily": "Inter",
+      "fontSize": 20,
+      "fontWeight": "700"
+    },
+    {
+      "type": "frame",
+      "id": "agOkl",
+      "x": 0,
+      "y": 1881,
+      "name": "BG1_クラフト紙風",
+      "clip": true,
+      "width": 400,
+      "height": 400,
+      "fill": "#D4B48A",
+      "layout": "none",
+      "children": [
+        {
+          "type": "script",
+          "id": "nl54I",
+          "x": 0,
+          "y": 0,
+          "name": "bg1lines",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/h_lines.js",
+          "inputs": {
+            "gap": 28,
+            "lineColor": "#C8A882",
+            "opacity": 0.35,
+            "thickness": 1
+          }
+        },
+        {
+          "type": "script",
+          "id": "kOmeF",
+          "x": 0,
+          "y": 0,
+          "name": "bg1corner",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/corner_deco.js",
+          "inputs": {
+            "size": 32,
+            "color": "#E87A2E",
+            "opacity": 0.75
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "bJ30W",
+          "x": 0,
+          "y": 0,
+          "name": "bg1accent",
+          "opacity": 0.5,
+          "fill": "#C8A882",
+          "width": 6,
+          "height": 400
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "sehAu",
+      "x": 450,
+      "y": 1881,
+      "name": "BG2_ネイビードット",
+      "clip": true,
+      "width": 400,
+      "height": 400,
+      "fill": "#2A2D5B",
+      "layout": "none",
+      "children": [
+        {
+          "type": "script",
+          "id": "dfBSX",
+          "x": 0,
+          "y": 0,
+          "name": "bg2dots",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/dot_grid.js",
+          "inputs": {
+            "dotSize": 3,
+            "gap": 28,
+            "dotColor": "#FAF0DE",
+            "opacity": 0.2
+          }
+        },
+        {
+          "type": "script",
+          "id": "SHrsR",
+          "x": 0,
+          "y": 0,
+          "name": "bg2corner",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/corner_deco.js",
+          "inputs": {
+            "size": 36,
+            "color": "#E87A2E",
+            "opacity": 0.9
+          }
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "C554Wt",
+      "x": 900,
+      "y": 1881,
+      "name": "BG3_手帳グリッド",
+      "clip": true,
+      "width": 400,
+      "height": 400,
+      "fill": "#FAFAF6",
+      "layout": "none",
+      "children": [
+        {
+          "type": "script",
+          "id": "E1nDQ",
+          "x": 0,
+          "y": 0,
+          "name": "bg3hlines",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/h_lines.js",
+          "inputs": {
+            "gap": 24,
+            "lineColor": "#B8C8E0",
+            "opacity": 0.5,
+            "thickness": 1
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "m8vJgS",
+          "x": 56,
+          "y": 0,
+          "name": "bg3vline",
+          "opacity": 0.35,
+          "fill": "#E87A2E",
+          "width": 1,
+          "height": 400
+        },
+        {
+          "type": "script",
+          "id": "vYHI5",
+          "x": 0,
+          "y": 0,
+          "name": "bg3dots",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/dot_grid.js",
+          "inputs": {
+            "dotSize": 2,
+            "gap": 24,
+            "dotColor": "#8898AA",
+            "opacity": 0.2
+          }
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "VCJkC",
+      "x": 1350,
+      "y": 1881,
+      "name": "BG4_スクラップブック",
+      "clip": true,
+      "width": 400,
+      "height": 400,
+      "fill": "#FAF0DE",
+      "layout": "none",
+      "children": [
+        {
+          "type": "rectangle",
+          "id": "H6l2K",
+          "x": 12,
+          "y": 12,
+          "name": "bg4border",
+          "opacity": 0.5,
+          "fill": "#00000000",
+          "width": 376,
+          "height": 376,
+          "stroke": {
+            "align": "inside",
+            "thickness": 2,
+            "fill": "#E87A2E"
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "bIC6l",
+          "x": 20,
+          "y": 20,
+          "name": "bg4border2",
+          "opacity": 0.2,
+          "fill": "#00000000",
+          "width": 360,
+          "height": 360,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#2A2D5B"
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "x98hWb",
+          "x": 12,
+          "y": 12,
+          "name": "bg4ctTL1",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 28,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "fEvZS",
+          "x": 12,
+          "y": 12,
+          "name": "bg4ctTL2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 28
+        },
+        {
+          "type": "rectangle",
+          "id": "pknOJ",
+          "x": 360,
+          "y": 12,
+          "name": "bg4ctTR1",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 28,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "h1SdG",
+          "x": 385,
+          "y": 12,
+          "name": "bg4ctTR2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 28
+        },
+        {
+          "type": "rectangle",
+          "id": "q6nIU9",
+          "x": 12,
+          "y": 385,
+          "name": "bg4ctBL1",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 28,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "CtkEf",
+          "x": 12,
+          "y": 360,
+          "name": "bg4ctBL2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 28
+        },
+        {
+          "type": "rectangle",
+          "id": "hL89T",
+          "x": 360,
+          "y": 385,
+          "name": "bg4ctBR1",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 28,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "sKQhS",
+          "x": 385,
+          "y": 360,
+          "name": "bg4ctBR2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 28
+        }
+      ]
+    },
+    {
+      "type": "frame",
+      "id": "z3jnQd",
+      "x": 1800,
+      "y": 1881,
+      "name": "BG5_ブラックボード風",
+      "clip": true,
+      "width": 400,
+      "height": 400,
+      "fill": "#161E2C",
+      "layout": "none",
+      "children": [
+        {
+          "type": "script",
+          "id": "R0fC0G",
+          "x": 0,
+          "y": 0,
+          "name": "bg5dots",
+          "width": 400,
+          "height": 400,
+          "scriptUri": "pen-scripts/dot_grid.js",
+          "inputs": {
+            "dotSize": 2,
+            "gap": 22,
+            "dotColor": "#FFFFFF",
+            "opacity": 0.08
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 2,
+          "id": "r5ILdY",
+          "x": 16,
+          "y": 16,
+          "name": "bg5border",
+          "opacity": 0.2,
+          "fill": "#00000000",
+          "width": 368,
+          "height": 368,
+          "stroke": {
+            "align": "inside",
+            "thickness": 2,
+            "fill": "#FFFFFF"
+          }
+        },
+        {
+          "type": "rectangle",
+          "cornerRadius": 2,
+          "id": "Z5SHoF",
+          "x": 22,
+          "y": 22,
+          "name": "bg5border2",
+          "opacity": 0.1,
+          "fill": "#00000000",
+          "width": 356,
+          "height": 356,
+          "stroke": {
+            "align": "inside",
+            "thickness": 1,
+            "fill": "#FFFFFF"
+          }
+        },
+        {
+          "type": "rectangle",
+          "id": "NJxWO",
+          "x": 16,
+          "y": 16,
+          "name": "bg5accentTL",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 40,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "FOLLq",
+          "x": 16,
+          "y": 16,
+          "name": "bg5accentTL2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 40
+        },
+        {
+          "type": "rectangle",
+          "id": "vOLhP",
+          "x": 344,
+          "y": 381,
+          "name": "bg5accentBR",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 40,
+          "height": 3
+        },
+        {
+          "type": "rectangle",
+          "id": "m89c1",
+          "x": 381,
+          "y": 344,
+          "name": "bg5accentBR2",
+          "opacity": 0.9,
+          "fill": "#E87A2E",
+          "width": 3,
+          "height": 40
+        }
+      ]
+    }
+  ]
+}

--- a/pen-scripts/corner_deco.js
+++ b/pen-scripts/corner_deco.js
@@ -1,0 +1,20 @@
+/** @schema 2.10
+ * @input size: number = 24
+ * @input color: color = #E87A2E
+ * @input opacity: number = 0.7
+ */
+const s = pencil.input.size;
+const c = pencil.input.color;
+const op = pencil.input.opacity;
+const w = pencil.width;
+const h = pencil.height;
+return [
+  { type: "rectangle", x: 0, y: 0, width: s, height: 3, fill: c, opacity: op },
+  { type: "rectangle", x: 0, y: 0, width: 3, height: s, fill: c, opacity: op },
+  { type: "rectangle", x: w - s, y: 0, width: s, height: 3, fill: c, opacity: op },
+  { type: "rectangle", x: w - 3, y: 0, width: 3, height: s, fill: c, opacity: op },
+  { type: "rectangle", x: 0, y: h - 3, width: s, height: 3, fill: c, opacity: op },
+  { type: "rectangle", x: 0, y: h - s, width: 3, height: s, fill: c, opacity: op },
+  { type: "rectangle", x: w - s, y: h - 3, width: s, height: 3, fill: c, opacity: op },
+  { type: "rectangle", x: w - 3, y: h - s, width: 3, height: s, fill: c, opacity: op },
+];

--- a/pen-scripts/dot_grid.js
+++ b/pen-scripts/dot_grid.js
@@ -1,0 +1,23 @@
+/** @schema 2.10
+ * @input dotSize: number = 3
+ * @input gap: number = 30
+ * @input dotColor: color = #FAF0DE
+ * @input opacity: number = 0.25
+ */
+const nodes = [];
+const cols = Math.ceil(pencil.width / pencil.input.gap) + 1;
+const rows = Math.ceil(pencil.height / pencil.input.gap) + 1;
+for (let r = 0; r < rows; r++) {
+  for (let c = 0; c < cols; c++) {
+    nodes.push({
+      type: "ellipse",
+      x: c * pencil.input.gap - pencil.input.dotSize / 2,
+      y: r * pencil.input.gap - pencil.input.dotSize / 2,
+      width: pencil.input.dotSize,
+      height: pencil.input.dotSize,
+      fill: pencil.input.dotColor,
+      opacity: pencil.input.opacity,
+    });
+  }
+}
+return nodes;

--- a/pen-scripts/h_lines.js
+++ b/pen-scripts/h_lines.js
@@ -1,0 +1,20 @@
+/** @schema 2.10
+ * @input gap: number = 28
+ * @input lineColor: color = #C8A882
+ * @input opacity: number = 0.3
+ * @input thickness: number = 1
+ */
+const nodes = [];
+const rows = Math.ceil(pencil.height / pencil.input.gap) + 1;
+for (let r = 0; r < rows; r++) {
+  nodes.push({
+    type: "rectangle",
+    x: 0,
+    y: r * pencil.input.gap,
+    width: pencil.width,
+    height: pencil.input.thickness,
+    fill: pencil.input.lineColor,
+    opacity: pencil.input.opacity,
+  });
+}
+return nodes;

--- a/project.yml
+++ b/project.yml
@@ -15,6 +15,9 @@ packages:
   FirebaseiOSSDK:
     url: https://github.com/firebase/firebase-ios-sdk
     from: "12.12.1"
+  GoogleMobileAds:
+    url: https://github.com/googleads/swift-package-manager-google-mobile-ads
+    from: "11.0.0"
 
 settings:
   base:
@@ -47,6 +50,8 @@ targets:
         NSPhotoLibraryUsageDescription: "シールにする写真を選択するためにフォトライブラリへのアクセスが必要です"
         NSCameraUsageDescription: "シールにする写真を撮影するためにカメラへのアクセスが必要です"
         NSPhotoLibraryAddUsageDescription: "ボードを画像として写真に保存するためにフォトライブラリへのアクセスが必要です"
+        NSUserTrackingUsageDescription: "広告をあなたの興味に合わせてパーソナライズするために使用します"
+        GADApplicationIdentifier: "ca-app-pub-3940256099942544~1458002511"
         UILaunchScreen: {}
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: "public.app-category.lifestyle"
@@ -73,6 +78,8 @@ targets:
         embed: true
       - package: FirebaseiOSSDK
         product: FirebaseCrashlytics
+      - package: GoogleMobileAds
+        product: GoogleMobileAds
     postBuildScripts:
       - script: |
           if [ -f "${SRCROOT}/StickerBoard/GoogleService-Info.plist" ]; then

--- a/project.yml
+++ b/project.yml
@@ -51,7 +51,7 @@ targets:
         NSCameraUsageDescription: "シールにする写真を撮影するためにカメラへのアクセスが必要です"
         NSPhotoLibraryAddUsageDescription: "ボードを画像として写真に保存するためにフォトライブラリへのアクセスが必要です"
         NSUserTrackingUsageDescription: "広告をあなたの興味に合わせてパーソナライズするために使用します"
-        GADApplicationIdentifier: "ca-app-pub-3940256099942544~1458002511"
+        GADApplicationIdentifier: "ca-app-pub-3940256099942544~1458002511"  # TODO: App Store提出前にAdMobコンソールの本番アプリIDに差し替えること
         UILaunchScreen: {}
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: "public.app-category.lifestyle"

--- a/project.yml
+++ b/project.yml
@@ -51,7 +51,7 @@ targets:
         NSCameraUsageDescription: "シールにする写真を撮影するためにカメラへのアクセスが必要です"
         NSPhotoLibraryAddUsageDescription: "ボードを画像として写真に保存するためにフォトライブラリへのアクセスが必要です"
         NSUserTrackingUsageDescription: "広告をあなたの興味に合わせてパーソナライズするために使用します"
-        GADApplicationIdentifier: "ca-app-pub-3940256099942544~1458002511"  # TODO: App Store提出前にAdMobコンソールの本番アプリIDに差し替えること
+        GADApplicationIdentifier: "ca-app-pub-6267199278067658~4057899774"
         UILaunchScreen: {}
         ITSAppUsesNonExemptEncryption: false
         LSApplicationCategoryType: "public.app-category.lifestyle"


### PR DESCRIPTION
## Summary

- **AdMob SDK 導入**: `GoogleMobileAds` 11.13.0 を SPM で追加（`project.yml`）
- **AdManager 実装**: `@Observable @MainActor` シングルトン。インタースティシャル・ネイティブ広告のロード/頻度管理（3回に1回）
- **ATT 対応**: オンボーディング完了後に `ATTrackingManager.requestTrackingAuthorization()` を要求。`GADMobileAds.start()` は ATT 決定後に呼ぶ設計
- **StickerLibraryView**: グリッドを12枚ごとにチャンク化し、最初の12枚チャンク後に `NativeAdCard` を挿入（重複インプレッション防止）
- **StickerLibraryView**: 写真保存アラート解除後にインタースティシャル広告をトリガー（#261）
- **BoardShareService**: 共有完了ハンドラでインタースティシャル広告をトリガー（#260）
- **BoardEditorView**: 写真保存アラート解除後にインタースティシャル広告をトリガー（#260）
- **Pro ユーザーには広告を一切表示しない**（`isProUser` チェックを全パスに実装 + `@ObservedObject` でリアクティブ反映）

## 広告が出ない場所（意図的）
- `BoardEditorView`（創作中は完全オフ）
- `StickerCaptureView`（カメラ操作中）
- `PaywallView` / `OnboardingView` / `SettingsView`

## ⚠️ App Store 提出前に必要な作業
- `project.yml` の `GADApplicationIdentifier` を本番アプリ ID に変更（TODO コメントあり）
- `AdManager.swift` の `AdUnitID` を本番広告ユニット ID に変更（TODO コメントあり）

## Test plan

- [ ] 無料ユーザー: シール一覧に12枚を超えるシールがある場合、12枚目以降に広告カードが表示されること
- [ ] 無料ユーザー: ボード「写真に保存」→ OK 後、3回に1回インタースティシャルが表示されること
- [ ] 無料ユーザー: 共有→完了後、3回に1回インタースティシャルが表示されること
- [ ] 無料ユーザー: シール「写真に保存」→ OK 後、3回に1回インタースティシャルが表示されること（ボードとカウンター共通）
- [ ] Pro ユーザー: 上記のいずれも広告が表示されないこと
- [ ] ビルドが通ること（`xcodebuild build`）
- [ ] `GADApplicationIdentifier` と AdUnit ID を本番 ID に差し替え済みであること（リリース前）

close #258
close #259
close #260
close #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)