### PR TITLE
perf: ボード編集のシールからホログラフィック効果を除去

### DIFF
--- a/StickerBoard/Views/Board/StickerItemView.swift
+++ b/StickerBoard/Views/Board/StickerItemView.swift
@@ -80,7 +80,6 @@ struct StickerItemView: View {
                 .resizable()
                 .scaledToFit()
                 .frame(width: 120, height: 120)
-                .holographicSticker(image: image, intensity: 0.4, enableRotation: false)
                 .shadow(color: .black.opacity(0.15), radius: 6, y: 3)
         } else {
             ZStack {


### PR DESCRIPTION
ボード上の全シールに常時適用されていたホログラフィック効果が
MotionManager の 30fps 更新でシール枚数分の画像マスク＋ブレンド
合成を毎フレーム再描画させ、編集（特にドラッグ）が重くなっていた。
ホログラフィックはシールライブラリのみで使用するため、
StickerItemView から除去する。

https://claude.ai/code/session_012zDkbzgdAgZiUkbiDRW7RT